### PR TITLE
lexer: added [] and {}

### DIFF
--- a/huff_lexer/src/lib.rs
+++ b/huff_lexer/src/lib.rs
@@ -211,6 +211,10 @@ impl<'a> Iterator for Lexer<'a> {
                 '(' => TokenKind::OpenParen,
                 ')' => TokenKind::CloseParen,
                 ',' => TokenKind::Comma,
+                "[" => TokenKind::OpenBracket,
+                "]" => TokenKind::CloseBracket,
+                "{" => TokenKind::OpenBrace,
+                "}" => TokenKind::CloseBrace,
 
                 ch => {
                     return Some(Err(LexicalError::new(


### PR DESCRIPTION
Generate tokens for the characters `[`, `]`, `{`and `}`.