### PR TITLE
Fixed the `References` section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ In order to fix any formatting issues, run:
 ```bash
 cargo +nightly fmt -- 
 ```
-```
 
 
 ## References


### PR DESCRIPTION
The `References` section in README.md was in an open-ended code block. 