### PR TITLE
refactor: reduce name ambiguity

### DIFF
--- a/huff_parser/src/lib.rs
+++ b/huff_parser/src/lib.rs
@@ -61,7 +61,7 @@ impl<'a> Parser<'a> {
         // NOTE: lexer considers newlines as whitespaces
         self.tokens.retain(|&token| !matches!(token.kind, TokenKind::Whitespace));
         while !self.check(TokenKind::Eof) {
-            self.parse_statement()?;
+            self.parse_definition()?;
         }
         Ok(())
     }
@@ -111,7 +111,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse a statement.
-    fn parse_statement(&mut self) -> Result<(), ParserError> {
+    fn parse_definition(&mut self) -> Result<(), ParserError> {
         // first token should be keyword "#define"
         self.match_kind(TokenKind::Define)?;
         // match to fucntion, constant or macro


### PR DESCRIPTION
## Overview

Currently, according to the AST, the term statement refers to either an opcode, a literal, or a macro invocation: effectively anything inside the body of a macro. However, in the parser, a statement is used to refer to anything ensuing a `#define` keyword.

## Solution

This PR renames the `parse_statement` function to `parse_definition`, to increase clarity.