### PR TITLE
feat(huff_parser): Validate FilePaths

### DIFF
--- a/huff_parser/tests/imports.rs
+++ b/huff_parser/tests/imports.rs
@@ -4,14 +4,29 @@ use huff_utils::prelude::*;
 
 #[test]
 fn parses_import() {
-    let c = " /* .,*./. */  #include \"./utils/ERC1155.huff\"";
+    let source = " /* .,*./. */  #include \"../huff_lexer/huffs/ERC20.huff\"";
 
-    let lexer = Lexer::new(c);
+    let lexer = Lexer::new(source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
     let mut parser = Parser::new(tokens);
     let contract = parser.parse().unwrap();
     assert_eq!(parser.current_token.kind, TokenKind::Eof);
 
     let import_path = contract.imports[0];
-    assert_eq!(import_path, "./utils/ERC1155.huff");
+    assert_eq!(import_path.to_str().unwrap(), "../huff_lexer/huffs/ERC20.huff");
+}
+
+#[test]
+#[should_panic]
+fn fails_to_parse_invalid_import() {
+    let source = " /* .,*./. */  #include \"../huff_lexer/huffs/ERC1155.huff\"";
+
+    let lexer = Lexer::new(source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens);
+    let contract = parser.parse().unwrap();
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+
+    let import_path = contract.imports[0];
+    assert_eq!(import_path.to_str().unwrap(), "../huff_lexer/huffs/ERC1155.huff");
 }

--- a/huff_utils/src/ast.rs
+++ b/huff_utils/src/ast.rs
@@ -1,11 +1,12 @@
 use crate::evm::Opcode;
+use std::path::Path;
 
 type Literal = [u8; 32];
 
 /// A File Path
 ///
 /// Used for parsing the huff imports.
-pub type FilePath<'a> = &'a str;
+pub type FilePath<'a> = &'a Path;
 
 /// A Huff Contract Representation
 ///


### PR DESCRIPTION
## Overview

Instead of storing file paths as a `&'a str`, uses a `std::path::Path` and throws an error if the path is invalid.

Invalid paths include:
* Non-existent paths
* Paths that do not point to a file
* Paths that point to a file that does not end in `.huff`

## Motivation

#58
