### PR TITLE
fix(huff_lexer): Don't include `0x` when lexing `Literal`s

### DIFF
--- a/huff_lexer/src/lib.rs
+++ b/huff_lexer/src/lib.rs
@@ -405,13 +405,14 @@ impl<'a> Iterator for Lexer<'a> {
                 }
                 // If it's the start of a hex literal
                 ch if ch == '0' && self.peek().unwrap() == 'x' => {
+                    self.consume(); // Consume the 'x' after '0' (separated from the `dyn_consume` so we don't have
+                                    // to match `x` in the actual hex)
                     self.dyn_consume(|c| {
                         c.is_numeric() ||
-                            // Match a-f, A-F, and 'x'
-                            // Note: This still allows for invalid hex, as it doesn't care if
-                            // there are multiple 'x' values in the literal.
-                            matches!(c, '\u{0041}'..='\u{0046}' | '\u{0061}'..='\u{0066}' | 'x')
+                        // Match a-f & A-F
+                        matches!(c, '\u{0041}'..='\u{0046}' | '\u{0061}'..='\u{0066}')
                     });
+                    self.span.start += 2; // Ignore the "0x"
                     let mut arr: [u8; 32] = Default::default();
                     let mut buf = BytesMut::from(self.slice());
                     buf.resize(32, 0);

--- a/huff_lexer/tests/hex.rs
+++ b/huff_lexer/tests/hex.rs
@@ -18,8 +18,8 @@ fn parses_single_hex() {
 
     // The first and only token should be lexed as Hex(0x1234)
     let tok = lexer.next().unwrap().unwrap();
-    assert_eq!(tok, Token::new(TokenKind::Literal(str_to_array(source)), Span::new(0..6)));
-    assert_eq!(lexer.span, Span::new(0..6));
+    assert_eq!(tok, Token::new(TokenKind::Literal(str_to_array("a57B")), Span::new(2..6)));
+    assert_eq!(lexer.span, Span::new(2..6));
 
     // We covered the whole source
     lexer.next();

--- a/huff_parser/tests/constant.rs
+++ b/huff_parser/tests/constant.rs
@@ -36,7 +36,7 @@ fn parses_literal_constant() {
     // Create const val
     let mut arr: [u8; 32] = Default::default();
     let mut buf =
-        BytesMut::from("0x8C5BE1E5EBEC7D5BD14F71427D1E84F3DD0314C0F7B2291E5B200AC8C7C3B925");
+        BytesMut::from("8C5BE1E5EBEC7D5BD14F71427D1E84F3DD0314C0F7B2291E5B200AC8C7C3B925");
     buf.resize(32, 0);
     arr.copy_from_slice(buf.as_ref());
 

--- a/huff_parser/tests/macro.rs
+++ b/huff_parser/tests/macro.rs
@@ -51,10 +51,10 @@ fn macro_with_simple_body() {
             name: "HELLO_WORLD".to_string(),
             parameters: vec![],
             statements: vec![
-                Statement::Literal(create_literal_from_str("0x00")),
+                Statement::Literal(create_literal_from_str("00")),
                 Statement::Opcode(Opcode::Mstore),
-                Statement::Literal(create_literal_from_str("0x01")),
-                Statement::Literal(create_literal_from_str("0x02")),
+                Statement::Literal(create_literal_from_str("01")),
+                Statement::Literal(create_literal_from_str("02")),
                 Statement::Opcode(Opcode::Add)
             ],
             takes: 3,


### PR DESCRIPTION
## Overview

Prevents `0x` from being consumed when lexing Literals, which are of type `[u8; 32]`. `0x` takes up 2 bytes, so the last 2 bytes of the 32 byte `Literal` are currently truncated.

Also fixes the lexer's pattern matching for hex values where other `x`'s could be included apart from the `x` in `0x`. Literals should only contain characters matching `[0-9a-fA-F]+`.

## Motivation

#57

## Solution

* Ignore the `0x` by increasing the span's start by 2 after `dyn_consume`ing the rest of the `Literal` value.
* Remove 'x' from the `dyn_consume`'s pattern match; `consume` it beforehand.