### PR TITLE
fix(huff_core): Missing File Erroring

### DIFF
--- a/huff_core/src/lib.rs
+++ b/huff_core/src/lib.rs
@@ -339,7 +339,7 @@ impl<'a> Compiler {
         }
         let import_bufs: Vec<PathBuf> = Compiler::transform_paths(&localized_imports)?;
         let potentials: Result<Vec<Arc<FileSource>>, CompilerError> =
-            Compiler::fetch_sources(import_bufs).iter().cloned().collect();
+            Compiler::fetch_sources(import_bufs).into_iter().collect();
         let mut file_sources = match potentials {
             Ok(p) => p,
             Err(e) => return Err(Arc::new(e)),

--- a/huff_core/tests/erc20.rs
+++ b/huff_core/tests/erc20.rs
@@ -8,9 +8,12 @@ use huff_utils::prelude::*;
 
 #[test]
 fn test_erc20_compile() {
-    let file_sources: Vec<Arc<FileSource>> = Compiler::fetch_sources(&vec![PathBuf::from(
+    let file_sources: Vec<Arc<FileSource>> = Compiler::fetch_sources(vec![PathBuf::from(
         "../huff-examples/erc20/contracts/ERC20.huff".to_string(),
-    )]);
+    )])
+    .iter()
+    .map(|p| p.clone().unwrap())
+    .collect();
 
     // Recurse file deps + generate flattened source
     let file_source = file_sources.get(0).unwrap();

--- a/huff_core/tests/erc721.rs
+++ b/huff_core/tests/erc721.rs
@@ -8,9 +8,12 @@ use huff_utils::prelude::*;
 
 #[test]
 fn test_erc721_compile() {
-    let file_sources: Vec<Arc<FileSource>> = Compiler::fetch_sources(&vec![PathBuf::from(
+    let file_sources: Vec<Arc<FileSource>> = Compiler::fetch_sources(vec![PathBuf::from(
         "../huff-examples/erc721/contracts/ERC721.huff".to_string(),
-    )]);
+    )])
+    .iter()
+    .map(|p| p.clone().unwrap())
+    .collect();
 
     // Recurse file deps + generate flattened source
     let file_source = file_sources.get(0).unwrap();

--- a/huff_core/tests/recurse_deps.rs
+++ b/huff_core/tests/recurse_deps.rs
@@ -5,9 +5,12 @@ use huff_utils::files::FileSource;
 
 #[test]
 fn test_recursing_fs_dependencies() {
-    let file_sources: Vec<Arc<FileSource>> = Compiler::fetch_sources(&vec![PathBuf::from(
+    let file_sources: Vec<Arc<FileSource>> = Compiler::fetch_sources(vec![PathBuf::from(
         "../huff-examples/erc20/contracts/ERC20.huff".to_string(),
-    )]);
+    )])
+    .iter()
+    .map(|p| p.clone().unwrap())
+    .collect();
     assert_eq!(file_sources.len(), 1);
     let erc20_file_source = file_sources[0].clone();
     let res = Compiler::recurse_deps(Arc::clone(&erc20_file_source));
@@ -22,9 +25,12 @@ fn test_recursing_fs_dependencies() {
 
 #[test]
 fn test_recursing_external_dependencies() {
-    let file_sources: Vec<Arc<FileSource>> = Compiler::fetch_sources(&vec![PathBuf::from(
+    let file_sources: Vec<Arc<FileSource>> = Compiler::fetch_sources(vec![PathBuf::from(
         "../huff-examples/erc20/contracts/ERC20.huff".to_string(),
-    )]);
+    )])
+    .iter()
+    .map(|p| p.clone().unwrap())
+    .collect();
     assert_eq!(file_sources.len(), 1);
     let erc20_file_source = file_sources[0].clone();
     let res = Compiler::recurse_deps(Arc::clone(&erc20_file_source));

--- a/huff_core/tests/sources.rs
+++ b/huff_core/tests/sources.rs
@@ -1,15 +1,18 @@
 use std::{path::PathBuf, sync::Arc};
 
 use huff_core::Compiler;
-use huff_utils::files::FileSource;
+use huff_utils::prelude::*;
 
 #[test]
 fn test_fetch_sources() {
-    let file_sources: Vec<Arc<FileSource>> = Compiler::fetch_sources(&vec![
+    let file_sources: Vec<Arc<FileSource>> = Compiler::fetch_sources(vec![
         PathBuf::from("../huff-examples/erc20/contracts/ERC20.huff".to_string()),
         PathBuf::from("../huff-examples/erc20/contracts/utils/Address.huff".to_string()),
         PathBuf::from("../huff-examples/erc20/contracts/utils/HashMap.huff".to_string()),
-    ]);
+    ])
+    .iter()
+    .map(|p| p.clone().unwrap())
+    .collect();
     assert_eq!(file_sources.len(), 3);
     assert_eq!(file_sources[0].path, "../huff-examples/erc20/contracts/ERC20.huff".to_string());
     assert_eq!(
@@ -24,12 +27,21 @@ fn test_fetch_sources() {
 
 #[test]
 fn test_fetch_invalid_sources() {
-    let file_sources: Vec<Arc<FileSource>> = Compiler::fetch_sources(&vec![
+    let paths = vec![
         PathBuf::from("../huff-examples/erc20/contracts/non_existant.huff".to_string()),
         PathBuf::from("../huff-examples/erc20/contracts/non_huff.txt".to_string()),
         PathBuf::from("../huff-examples/erc20/contracts/random/Address.huff".to_string()),
         PathBuf::from("../huff-examples/erc20/contracts/random/".to_string()),
         PathBuf::from("../huff-examples/erc20/contracts/utils/".to_string()),
-    ]);
-    assert_eq!(file_sources.len(), 0);
+    ];
+    #[allow(clippy::needless_collect)]
+    let file_sources: Vec<Result<Arc<FileSource>, CompilerError>> =
+        Compiler::fetch_sources(paths.clone());
+    for (i, e) in file_sources.iter().enumerate() {
+        let file_loc = String::from(paths[i].to_string_lossy());
+        assert_eq!(
+            e.clone().err().unwrap(),
+            CompilerError::FileUnpackError(UnpackError::MissingFile(file_loc))
+        )
+    }
 }

--- a/huff_core/tests/sources.rs
+++ b/huff_core/tests/sources.rs
@@ -34,7 +34,6 @@ fn test_fetch_invalid_sources() {
         PathBuf::from("../huff-examples/erc20/contracts/random/".to_string()),
         PathBuf::from("../huff-examples/erc20/contracts/utils/".to_string()),
     ];
-    #[allow(clippy::needless_collect)]
     let file_sources: Vec<Result<Arc<FileSource>, CompilerError>> =
         Compiler::fetch_sources(paths.clone());
     for (i, e) in file_sources.iter().enumerate() {

--- a/huff_utils/src/error.rs
+++ b/huff_utils/src/error.rs
@@ -258,6 +258,9 @@ impl<'a> fmt::Display for CompilerError<'a> {
                         unsupported
                     )
                 }
+                UnpackError::MissingFile(file) => {
+                    write!(f, "\nError: File Not Found \"{}\"\n", file)
+                }
             },
             CompilerError::ParserError(pe) => match &pe.kind {
                 ParserErrorKind::SyntaxError(se) => {

--- a/huff_utils/src/io.rs
+++ b/huff_utils/src/io.rs
@@ -12,6 +12,8 @@ pub enum UnpackError {
     UnsupportedExtension(String),
     /// Failed to read directory
     InvalidDirectory(String),
+    /// Missing File
+    MissingFile(String),
 }
 
 /// Unpacks huff files into a vec of strings.


### PR DESCRIPTION
## Overview

This PR properly bubbles up file fetching errors instead of gracefully allowing `0` files to compile.

Effect (the first run is the original `huffc` output, second is the output created by this pr):
<img width="814" alt="Screen Shot 2022-06-24 at 7 55 57 AM" src="https://user-images.githubusercontent.com/21288394/175531199-48294a4a-e557-46b7-971c-80b358c8082f.png">
