### PR TITLE
fix(tracing): Make tracing more readable

### DIFF
--- a/huff_codegen/src/irgen/statements.rs
+++ b/huff_codegen/src/irgen/statements.rs
@@ -18,7 +18,7 @@ pub fn statement_gen(
 ) -> Result<Vec<(usize, Bytes)>, CodegenError> {
     let mut bytes = vec![];
 
-    tracing::debug!(target: "codegen", "Got Statement: {:?}", s);
+    tracing::debug!(target: "codegen", "Got Statement: {}", s.ty);
 
     match &s.ty {
         StatementType::MacroInvocation(mi) => {
@@ -58,7 +58,7 @@ pub fn statement_gen(
                 };
 
             // Set jump table values
-            tracing::debug!(target: "codegen", "Unmatched jumps: {:?}", res.unmatched_jumps);
+            tracing::debug!(target: "codegen", "Unmatched jumps: {:?}", res.unmatched_jumps.iter().map(|uj| uj.label.clone()).collect::<Vec<String>>());
             for j in res.unmatched_jumps.iter_mut() {
                 let new_index = j.bytecode_index;
                 j.bytecode_index = 0;
@@ -80,7 +80,7 @@ pub fn statement_gen(
         }
         StatementType::Label(label) => {
             // Add JUMPDEST opcode to final result and add to label_indices
-            tracing::info!(target: "codegen", "RECURSE BYTECODE GOT LABEL: {:?}", label);
+            tracing::info!(target: "codegen", "RECURSE BYTECODE GOT LABEL: {:?}", label.name);
             label_indices.insert(label.name.clone(), *offset);
             bytes.push((*offset, Bytes(Opcode::Jumpdest.to_string())));
             *offset += 1;

--- a/huff_core/src/lib.rs
+++ b/huff_core/src/lib.rs
@@ -185,7 +185,7 @@ impl<'a> Compiler {
             file: Some(Arc::clone(&file)),
             spans: flattened.1,
         };
-        tracing::debug!(target: "core", "GOT FULL SOURCE: \"{:?}\"", full_source);
+        tracing::debug!(target: "core", "GOT FULL SOURCE FOR PATH: {:?}", file.path);
 
         // Perform Lexical Analysis
         // Create a new lexer from the FileSource, flattening dependencies

--- a/huff_utils/src/ast.rs
+++ b/huff_utils/src/ast.rs
@@ -8,7 +8,11 @@ use crate::{
     evm::Opcode,
     prelude::{Span, TokenKind},
 };
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{
+    collections::BTreeMap,
+    fmt::{Display, Formatter},
+    path::PathBuf,
+};
 
 /// A contained literal
 pub type Literal = [u8; 32];
@@ -625,4 +629,23 @@ pub enum StatementType {
     LabelCall(String),
     /// A built-in function call
     BuiltinFunctionCall(BuiltinFunctionCall),
+}
+
+impl Display for StatementType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StatementType::Literal(l) => write!(f, "LITERAL: {}", bytes32_to_string(l, true)),
+            StatementType::Opcode(o) => write!(f, "OPCODE: {}", o),
+            StatementType::MacroInvocation(m) => {
+                write!(f, "MACRO INVOCATION: {}", m.macro_name)
+            }
+            StatementType::Constant(c) => write!(f, "CONSTANT: {}", c),
+            StatementType::ArgCall(c) => write!(f, "ARG CALL: {}", c),
+            StatementType::Label(l) => write!(f, "LABEL: {}", l.name),
+            StatementType::LabelCall(l) => write!(f, "LABEL CALL: {}", l),
+            StatementType::BuiltinFunctionCall(b) => {
+                write!(f, "BUILTIN FUNCTION CALL: {:?}", b.kind)
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Overview

Truncates tracing values to make the `-v`/`--verbose` flag output more readable.

#123

New output:
![Peek 2022-06-24 12-48](https://user-images.githubusercontent.com/8406232/175605200-e0e21435-3a95-4cf8-9e01-53b1ea1a7897.gif)