### PR TITLE
fix(huff_core): Artifact Exports Off By Default

### DIFF
--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -39,6 +39,10 @@ struct Huff {
     #[clap(short = 'i', long = "inputs", multiple_values = true)]
     inputs: Option<Vec<String>>,
 
+    /// Whether to generate artifacts or not
+    #[clap(short = 'a', long = "artifacts")]
+    artifacts: bool,
+
     /// Optimize compilation.
     #[clap(short = 'z', long = "optimize")]
     optimize: bool,
@@ -75,9 +79,10 @@ fn main() {
     };
     let compiler: Compiler = Compiler {
         sources: Arc::clone(&sources),
-        output: match &cli.output {
-            Some(o) => Some(o.clone()),
-            None => Some(cli.outputdir.clone()),
+        output: match (&cli.output, cli.artifacts) {
+            (Some(o), true) => Some(o.clone()),
+            (None, true) => Some(cli.outputdir.clone()),
+            _ => None,
         },
         construct_args: cli.inputs,
         optimize: cli.optimize,

--- a/huff_core/src/lib.rs
+++ b/huff_core/src/lib.rs
@@ -371,16 +371,32 @@ impl<'a> Compiler {
     /// 1. Cleans any previous artifacts in the output directory.
     /// 2. Exports artifacts in parallel as serialized json `Artifact` objects.
     pub fn export_artifacts(artifacts: &Vec<Arc<Artifact>>, output: &OutputLocation) {
+        // Exit if empty output location
+        if output.0.is_empty() {
+            tracing::warn!(target: "core", "Exiting artifact export with empty output location!");
+            return
+        }
+
         // Clean the Output Directory
         tracing::warn!(target: "core", "REMOVING DIRECTORY: \"{}\"", output.0);
         if !output.0.is_empty() && fs::remove_dir_all(&output.0).is_ok() {
             tracing::info!(target: "core", "OUTPUT DIRECTORY DELETED!");
         }
 
+        // Is the output a directory or a file?
+        let is_file = std::path::PathBuf::from(&output.0).extension().is_some();
+
         // Export the artifacts with parallelized io
         artifacts.into_par_iter().for_each(|a| {
-            let json_out =
-                format!("{}/{}.json", output.0, a.file.path.to_uppercase().replacen("./", "", 1));
+            // If it's a file type, we just export to `output.0`
+            let json_out = match is_file {
+                true => output.0.clone(),
+                false => format!(
+                    "{}/{}.json",
+                    output.0,
+                    a.file.path.to_uppercase().replacen("./", "", 1)
+                ),
+            };
             tracing::debug!(target: "core", "JSON OUTPUT: {:?}", json_out);
 
             if let Err(e) = a.export(&json_out) {

--- a/huff_core/src/lib.rs
+++ b/huff_core/src/lib.rs
@@ -397,7 +397,6 @@ impl<'a> Compiler {
                     a.file.path.to_uppercase().replacen("./", "", 1)
                 ),
             };
-            tracing::debug!(target: "core", "JSON OUTPUT: {:?}", json_out);
 
             if let Err(e) = a.export(&json_out) {
                 tracing::error!(target: "core", "ARTIFACT EXPORT FAILED!\nError: {:?}", e);

--- a/huff_utils/src/artifact.rs
+++ b/huff_utils/src/artifact.rs
@@ -24,7 +24,7 @@ pub struct Artifact {
 impl Artifact {
     /// Exports an artifact to a json file
     pub fn export(&self, out: &str) -> std::result::Result<(), std::io::Error> {
-        let serialized_artifact = serde_json::to_string(self)?;
+        let serialized_artifact = serde_json::to_string_pretty(self)?;
         let file_path = Path::new(out);
         if let Some(p) = file_path.parent() {
             tracing::debug!(target: "abi", "Creating directory: \"{:?}\"", p);

--- a/huff_utils/src/files.rs
+++ b/huff_utils/src/files.rs
@@ -10,7 +10,7 @@ pub struct OutputLocation(pub String);
 
 impl Default for OutputLocation {
     fn default() -> Self {
-        Self("".to_string())
+        Self(String::default())
     }
 }
 
@@ -68,7 +68,7 @@ impl FileSource {
     pub fn fully_flatten(self_ref: Arc<FileSource>) -> (String, Vec<(Arc<FileSource>, Span)>) {
         // First grab the parent file source
         let mut full_source =
-            if let Some(s) = &self_ref.source { s.clone() } else { "".to_string() };
+            if let Some(s) = &self_ref.source { s.clone() } else { String::default() };
         let span = Span::new(0..full_source.len(), None);
         let mut relative_positions = vec![(Arc::clone(&self_ref), span)];
 

--- a/huff_utils/src/files.rs
+++ b/huff_utils/src/files.rs
@@ -10,7 +10,7 @@ pub struct OutputLocation(pub String);
 
 impl Default for OutputLocation {
     fn default() -> Self {
-        Self("./artifacts/".to_string())
+        Self("".to_string())
     }
 }
 


### PR DESCRIPTION
## Overview

Introduces a new `-a` (`--artifacts` longhand) flag to enable artifact output.
Even if the output directory or output location is specified by the respective `-o` and `-d` flags, if the artifacts flag is not added, `huffc` will **not** export anything.

closes #127 