### PR TITLE
fix(huff_cli): Only output a spinner if stdout is a TTY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -292,7 +298,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -302,7 +308,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -314,7 +320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -327,7 +333,7 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -584,7 +590,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -651,6 +657,7 @@ dependencies = [
  "ethers-core",
  "huff_core",
  "huff_utils",
+ "isatty",
  "spinners",
  "tracing",
  "uuid",
@@ -784,7 +791,19 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "isatty"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "redox_syscall 0.1.57",
+ "winapi",
 ]
 
 [[package]]
@@ -823,7 +842,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
  "sec1",
@@ -854,7 +873,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1241,6 +1260,12 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
@@ -1577,10 +1602,10 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.13",
  "remove_dir_all",
  "winapi",
 ]
@@ -1672,7 +1697,7 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1840,7 +1865,7 @@ version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 

--- a/huff_cli/Cargo.toml
+++ b/huff_cli/Cargo.toml
@@ -20,6 +20,7 @@ ethers-core = "0.13.0"
 yansi = "0.5.1"
 spinners = "4.1.0"
 uuid = { version = "1.1.1", features = ["v4"] }
+isatty = "0.1.9"
 
 [[bin]]
 name = "huffc"

--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -133,7 +133,7 @@ fn main() {
             }
             if cli.bytecode {
                 match sources.len() {
-                    1 => println!("{}", artifacts[0].bytecode),
+                    1 => print!("{}", artifacts[0].bytecode),
                     _ => artifacts
                         .iter()
                         .for_each(|a| println!("\"{}\" bytecode: {}", a.file.path, a.bytecode)),

--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -12,6 +12,7 @@ use huff_core::Compiler;
 use huff_utils::prelude::{
     unpack_files, AstSpan, CodegenError, CodegenErrorKind, CompilerError, FileSource, Span,
 };
+use isatty::stdout_isatty;
 use spinners::{Spinner, Spinners};
 use std::{path::Path, sync::Arc};
 use yansi::Paint;
@@ -91,11 +92,18 @@ fn main() {
 
     // Create compiling spinner
     tracing::debug!(target: "core", "[⠔] COMPILING");
-    let mut sp = Spinner::new(Spinners::Dots, "Compiling...".into());
+    let mut sp: Option<Spinner> = None;
+    // If stdout is a TTY, create a spinner
+    if stdout_isatty() {
+        sp = Some(Spinner::new(Spinners::Dots, "Compiling...".into()));
+    }
 
     let compile_res = compiler.execute();
-    sp.stop();
-    println!(" ");
+    // Stop spinner animation if it exists
+    if let Some(mut sp) = sp {
+        sp.stop();
+        println!(" ");
+    }
     match compile_res {
         Ok(artifacts) => {
             if artifacts.is_empty() {


### PR DESCRIPTION
## Overview

Prevents piped output from including the `Compiling` spinner.

closes #133 

### Checklist
- [x] Test on Linux (tested on: Ubuntu 20.04.4 LTS)
- [x] Test on Mac (tested on: macOS Monterey)
- [ ] Test on Windows (tested on: ~) **NOTE:** TTY detection works differently on windows, need to test this before merging.