### PR TITLE
fix(workflow): Build nightly on `stage` branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout stage branch if Nightly
+        if: ${{ env.IS_NIGHTLY }}
+        run: |
+          git checkout stage
+
       - name: Compute release name and tag
         id: release_info
         run: |


### PR DESCRIPTION
## Overview

Changes the release workflow to build the nightly release off of the `stage` branch.