### PR TITLE
docs: add steps to remove old version of huffc

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ To avoid redirecting the script directly into bash, download and run the [huffup
 
 To install the Huff compiler, simply run `huffup`.
 
+If you have the old [huffc (TypeScript version)](https://github.com/huff-language/huffc) npm package installed globally, you can remove it with:
+```bash
+sudo yarn global remove huffc
+```
+
+To make sure you are running the rust version, you can run `huffc --version` and it should respond with `huff_cli <version>`.  If it responds with `2.0.0` that means you are running the Typescript version.
+```bash
+$ huffc --version
+huff_cli 0.1.0
+```
+
 **Alternatively**
 
 Install from source by running:


### PR DESCRIPTION
## Overview

> Please provide a short description here and review the requirements below.

I was having probs removing the old huffc npm package and didnt even realize it at first because it seemed to take when i ran `yarn global remove huffc` and also i didnt know what version we were on or that the --help files look different now.  Finally after some headbanging I realized i was still running the old version and went back and tried removing it again but with `sudo` this time, and that worked.

Thought I'd add something in the docs here to help others in case they have a similar experience.
