### PR TITLE
feat(huff_cli): Solidity interface generation

### DIFF
--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -12,8 +12,8 @@ use ethers_core::utils::hex;
 use huff_codegen::Codegen;
 use huff_core::Compiler;
 use huff_utils::prelude::{
-    unpack_files, AstSpan, CodegenError, CodegenErrorKind, CompilerError, FileSource,
-    OutputLocation, Span,
+    gen_sol_interfaces, unpack_files, AstSpan, CodegenError, CodegenErrorKind, CompilerError,
+    FileSource, OutputLocation, Span,
 };
 use isatty::stdout_isatty;
 use spinners::{Spinner, Spinners};
@@ -54,6 +54,10 @@ struct Huff {
     /// Optimize compilation [WIP]
     #[clap(short = 'z', long = "optimize")]
     optimize: bool,
+
+    /// Generate solidity interface for a Huff artifact
+    #[clap(short = 'g', long = "interface")]
+    interface: bool,
 
     /// Generate and log bytecode.
     #[clap(short = 'b', long = "bytecode")]
@@ -162,6 +166,12 @@ fn main() {
                 eprintln!("{}", Paint::red(format!("{}", e)));
                 std::process::exit(1);
             }
+
+            if cli.interface {
+                tracing::info!(target: "cli", "GENERATING SOLIDITY INTERFACES FROM ARTIFACTS");
+                gen_sol_interfaces(&artifacts).iter().for_each(|i| println!("{}", i));
+            }
+
             if cli.bytecode {
                 if cli.interactive {
                     tracing::info!(target: "cli", "ENTERING INTERACTIVE MODE");

--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -12,8 +12,8 @@ use ethers_core::utils::hex;
 use huff_codegen::Codegen;
 use huff_core::Compiler;
 use huff_utils::prelude::{
-    gen_sol_interfaces, unpack_files, AstSpan, CodegenError, CodegenErrorKind, CompilerError,
-    FileSource, OutputLocation, Span,
+    export_interfaces, gen_sol_interfaces, unpack_files, AstSpan, CodegenError, CodegenErrorKind,
+    CompilerError, FileSource, OutputLocation, Span,
 };
 use isatty::stdout_isatty;
 use spinners::{Spinner, Spinners};
@@ -169,7 +169,26 @@ fn main() {
 
             if cli.interface {
                 tracing::info!(target: "cli", "GENERATING SOLIDITY INTERFACES FROM ARTIFACTS");
-                gen_sol_interfaces(&artifacts).iter().for_each(|i| println!("{}", i));
+                let interfaces = gen_sol_interfaces(&artifacts);
+                if export_interfaces(&interfaces).is_ok() {
+                    tracing::info!(target: "cli", "GENERATED SOLIDITY INTERFACES FROM ARTIFACTS SUCCESSFULLY");
+                    println!(
+                        "Exported Solidity Interfaces: {}",
+                        Paint::blue(
+                            interfaces
+                                .into_iter()
+                                .map(|(i, _)| format!("I{}.sol", i))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        )
+                    );
+                } else {
+                    tracing::error!(target: "cli", "FAILED TO GENERATE SOLIDITY INTERFACES FROM ARTIFACTS");
+                    eprintln!(
+                        "{}",
+                        Paint::red("FAILED TO GENERATE SOLIDITY INTERFACES FROM ARTIFACTS")
+                    );
+                }
             }
 
             if cli.bytecode {

--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -177,7 +177,7 @@ fn main() {
                         Paint::blue(
                             interfaces
                                 .into_iter()
-                                .map(|(i, _)| format!("I{}.sol", i))
+                                .map(|(_, i, _)| format!("I{}.sol", i))
                                 .collect::<Vec<_>>()
                                 .join(", ")
                         )

--- a/huff_utils/src/abi.rs
+++ b/huff_utils/src/abi.rs
@@ -269,6 +269,20 @@ pub enum FunctionParamType {
     Tuple(Vec<FunctionParamType>),
 }
 
+impl FunctionParamType {
+    /// Checks if the param type should be designated as "memory" for solidity interface
+    /// generation.
+    pub fn is_memory_type(&self) -> bool {
+        matches!(
+            self,
+            FunctionParamType::Bytes |
+                FunctionParamType::String |
+                FunctionParamType::Tuple(_) |
+                FunctionParamType::Array(_, _)
+        )
+    }
+}
+
 impl fmt::Debug for FunctionParamType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.display(f)

--- a/huff_utils/src/abi.rs
+++ b/huff_utils/src/abi.rs
@@ -164,7 +164,7 @@ impl From<ast::Contract> for Abi {
                             .map(|argument| EventParam {
                                 name: argument.name.clone().unwrap_or_default(),
                                 kind: argument.arg_type.clone().unwrap_or_default().into(),
-                                indexed: false, // TODO: This is not present in `argument`
+                                indexed: argument.indexed,
                             })
                             .collect(),
                         anonymous: false,

--- a/huff_utils/src/ast.rs
+++ b/huff_utils/src/ast.rs
@@ -336,6 +336,18 @@ pub enum FunctionType {
     Pure,
 }
 
+impl FunctionType {
+    /// Get the string representation of the function type for usage in Solidity interface
+    /// generation.
+    pub fn interface_mutability(&self) -> &str {
+        match self {
+            FunctionType::View => " view",
+            FunctionType::Pure => " pure",
+            _ => "", // payable / nonpayable types not valid in Solidity interfaces
+        }
+    }
+}
+
 /// An Event Signature
 #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Event {

--- a/huff_utils/src/lib.rs
+++ b/huff_utils/src/lib.rs
@@ -42,10 +42,13 @@ pub mod types;
 /// Bytes Util Module
 pub mod bytes_util;
 
+/// Solidity Interface Generator
+pub mod sol_interface;
+
 /// Prelude wraps common utilities.
 pub mod prelude {
     pub use crate::{
         abi::*, artifact::*, ast::*, bytecode::*, bytes_util::*, error::*, evm::*, files::*, io::*,
-        report::*, token::*, types::*,
+        report::*, sol_interface::*, token::*, types::*,
     };
 }

--- a/huff_utils/src/sol_interface.rs
+++ b/huff_utils/src/sol_interface.rs
@@ -1,11 +1,15 @@
 use crate::prelude::Artifact;
-use std::{fs, path::Path, sync::Arc};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 /// Generate solidity interfaces from a vector of artifacts.
 ///
 /// @param artifacts The vector of artifacts to generate interfaces from.
 /// @return The vector of generated interfaces.
-pub fn gen_sol_interfaces(artifacts: &Vec<Arc<Artifact>>) -> Vec<(&str, String)> {
+pub fn gen_sol_interfaces(artifacts: &Vec<Arc<Artifact>>) -> Vec<(PathBuf, &str, String)> {
     let mut interfaces = Vec::new();
 
     for artifact in artifacts {
@@ -70,6 +74,7 @@ pub fn gen_sol_interfaces(artifacts: &Vec<Arc<Artifact>>) -> Vec<(&str, String)>
             let interface_name =
                 artifact.file.path.split('/').last().unwrap().split('.').next().unwrap();
             interfaces.push((
+                Path::new(&artifact.file.path).parent().unwrap().to_path_buf(),
                 interface_name,
                 format!("interface I{} {{\n{}\n}}", interface_name, defs.join("\n"),),
             ));
@@ -83,9 +88,9 @@ pub fn gen_sol_interfaces(artifacts: &Vec<Arc<Artifact>>) -> Vec<(&str, String)>
 ///
 /// @param interfaces The vector of generated interfaces.
 /// @return Unit type if success, error if failure.
-pub fn export_interfaces(interfaces: &Vec<(&str, String)>) -> Result<(), std::io::Error> {
-    for (name, interface) in interfaces {
-        let path_str = format!("./I{}.sol", name);
+pub fn export_interfaces(interfaces: &Vec<(PathBuf, &str, String)>) -> Result<(), std::io::Error> {
+    for (path, name, interface) in interfaces {
+        let path_str = format!("{}/I{}.sol", path.to_str().unwrap_or(""), name);
         let file_path = Path::new(&path_str);
         fs::write(file_path, interface)?;
     }

--- a/huff_utils/src/sol_interface.rs
+++ b/huff_utils/src/sol_interface.rs
@@ -1,0 +1,79 @@
+use crate::prelude::Artifact;
+use std::sync::Arc;
+
+/// Generate solidity interfaces from a vector of artifacts.
+///
+/// @param artifacts The vector of artifacts to generate interfaces from.
+/// @return The vector of generated interfaces.
+pub fn gen_sol_interfaces(artifacts: &Vec<Arc<Artifact>>) -> Vec<String> {
+    let mut interfaces = Vec::new();
+
+    for artifact in artifacts {
+        if let Some(a) = &artifact.abi {
+            let mut defs = Vec::new();
+            a.events.iter().for_each(|(_, f)| {
+                defs.push(format!(
+                    "{}event {}({});",
+                    "\t",
+                    f.name,
+                    f.inputs
+                        .iter()
+                        .map(|i| {
+                            format!(
+                                "{}{}",
+                                i.kind,
+                                if i.indexed {
+                                    String::from(" indexed")
+                                } else {
+                                    String::default()
+                                }
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                ));
+            });
+            a.functions.iter().for_each(|(_, f)| {
+                defs.push(format!(
+                    "{}function {}({}) external{}{};",
+                    "\t",
+                    f.name,
+                    f.inputs
+                        .iter()
+                        .map(|i| format!(
+                            "{}{}",
+                            i.kind,
+                            if i.kind.is_memory_type() { " memory" } else { "" }
+                        ))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    f.state_mutability.interface_mutability(),
+                    if f.outputs.is_empty() {
+                        String::default()
+                    } else {
+                        format!(
+                            " returns ({})",
+                            f.outputs
+                                .iter()
+                                .map(|o| format!(
+                                    "{}{}",
+                                    o.kind,
+                                    if o.kind.is_memory_type() { " memory" } else { "" }
+                                ))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        )
+                    },
+                ));
+            });
+
+            interfaces.push(format!(
+                "interface I{} {{\n{}\n}}",
+                artifact.file.path.split('/').last().unwrap().split('.').next().unwrap(),
+                defs.join("\n"),
+            ));
+        }
+    }
+
+    interfaces
+}


### PR DESCRIPTION
## Overview

Adds a new flag to the CLI (`-g, --interface`) to generate a solidity interface for a Huff contract.
![Screenshot from 2022-07-03 15-55-30](https://user-images.githubusercontent.com/8406232/177055336-35f5576c-d756-4f6f-8352-b8ce37c6a58d.png)

### Checklist
- [x] Interface generation
- [x] Fix `indexed` keyword for event params.
- [x] Add option to output generated interface to a file (?)
