### PR TITLE
fix(huff_lexer): opcode lexing bug

### DIFF
--- a/huff_lexer/src/lib.rs
+++ b/huff_lexer/src/lib.rs
@@ -454,7 +454,7 @@ impl<'a> Iterator for Lexer<'a> {
                         }
                     }
 
-                    let pot_op = self.dyn_peek(|c| c.is_alphanumeric());
+                    let pot_op = self.dyn_peek(|c| c.is_alphanumeric() || c == &'_');
 
                     // Syntax sugar: true evaluates to 0x01, false evaluates to 0x00
                     if matches!(pot_op.as_str(), "true" | "false") {

--- a/huff_lexer/tests/labels.rs
+++ b/huff_lexer/tests/labels.rs
@@ -19,3 +19,22 @@ fn parse_label() {
     );
     assert_eq!(tokens.get(tokens.len() - 4).unwrap().kind, TokenKind::Colon);
 }
+
+#[test]
+fn parse_label_with_opcode_name() {
+    let source =
+        "#define macro HELLO_WORLD() = takes(3) returns(0) {\n0x00 mstore\n 0x01 0x02 add cool_label_return_swap1_mload:\n0x01\n}";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer
+        .into_iter()
+        .map(|x| x.unwrap())
+        .filter(|x| !matches!(x.kind, TokenKind::Whitespace))
+        .collect::<Vec<Token>>();
+
+    assert_eq!(
+        tokens.get(tokens.len() - 5).unwrap().kind,
+        TokenKind::Label("cool_label_return_swap1_mload".to_string())
+    );
+    assert_eq!(tokens.get(tokens.len() - 4).unwrap().kind, TokenKind::Colon);
+}


### PR DESCRIPTION
I ran into an interesting edge case today when naming a jump label `return_uint`. Because of the way opcodes are parsed, attempting to push this label to the stack mistakenly gets parsed as a `return` opcode. This small change handles this case by including underscores when peeking for an opcode.