### PR TITLE
fix: Invalid Parameter Types

### DIFF
--- a/huff_parser/src/lib.rs
+++ b/huff_parser/src/lib.rs
@@ -688,8 +688,7 @@ impl Parser {
     ) -> Result<Vec<Argument>, ParserError> {
         let mut args: Vec<Argument> = Vec::new();
         self.match_kind(TokenKind::OpenParen)?;
-        tracing::debug!(target: "parser", "PARSING ARGS...");
-        tracing::debug!(target: "parser", "PARSING ARGs: {:?}", self.current_token);
+        tracing::debug!(target: "parser", "PARSING ARGs: {:?}", self.current_token.kind);
         while !self.check(TokenKind::CloseParen) {
             // The builtin functions `__FUNC_SIG` and `__EVENT_HASH` can accept a single string as
             // input. If the `is_builtin` flag was passed, check to see if a single
@@ -716,8 +715,6 @@ impl Parser {
             let mut arg = Argument::default();
             let mut arg_spans = vec![];
 
-            // tracing::debug!(target: "parser", "PARSING ARGUMENT TYPE");
-
             // type comes first
             if select_type {
                 arg_spans.push(self.current_token.span.clone());
@@ -741,7 +738,7 @@ impl Parser {
                 self.consume();
             }
 
-            // If both arg type and arg name are none, we error here
+            // If both arg type and arg name are none, we didn't consume anything
             if arg.arg_type.is_none() && arg.name.is_none() {
                 tracing::error!(target: "parser", "INVALID ARGUMENT TOKEN: {:?}", self.current_token.kind);
                 return Err(ParserError {

--- a/huff_parser/src/lib.rs
+++ b/huff_parser/src/lib.rs
@@ -688,6 +688,8 @@ impl Parser {
     ) -> Result<Vec<Argument>, ParserError> {
         let mut args: Vec<Argument> = Vec::new();
         self.match_kind(TokenKind::OpenParen)?;
+        tracing::debug!(target: "parser", "PARSING ARGS...");
+        tracing::debug!(target: "parser", "PARSING ARGs: {:?}", self.current_token);
         while !self.check(TokenKind::CloseParen) {
             // The builtin functions `__FUNC_SIG` and `__EVENT_HASH` can accept a single string as
             // input. If the `is_builtin` flag was passed, check to see if a single
@@ -714,6 +716,8 @@ impl Parser {
             let mut arg = Argument::default();
             let mut arg_spans = vec![];
 
+            // tracing::debug!(target: "parser", "PARSING ARGUMENT TYPE");
+
             // type comes first
             if select_type {
                 arg_spans.push(self.current_token.span.clone());
@@ -735,6 +739,16 @@ impl Parser {
             // multiple args possible
             if self.check(TokenKind::Comma) {
                 self.consume();
+            }
+
+            // If both arg type and arg name are none, we error here
+            if arg.arg_type.is_none() && arg.name.is_none() {
+                tracing::error!(target: "parser", "INVALID ARGUMENT TOKEN: {:?}", self.current_token.kind);
+                return Err(ParserError {
+                    kind: ParserErrorKind::InvalidArgs(self.current_token.kind.clone()),
+                    hint: None,
+                    spans: AstSpan(vec![self.current_token.span.clone()]),
+                })
             }
 
             arg.span = AstSpan(arg_spans);

--- a/huff_parser/tests/breaking_param_invocation.rs
+++ b/huff_parser/tests/breaking_param_invocation.rs
@@ -1,0 +1,53 @@
+use huff_lexer::*;
+use huff_parser::*;
+use huff_utils::prelude::*;
+
+#[test]
+#[should_panic]
+fn test_breaking_param_invocation() {
+    let source: &str = r#"
+        // Here we have a macro invocation directly in the parameter list - this should fail
+        #define macro TEST(<value>) = takes(0) returns(0) {
+            <value> 0x00 mstore
+            0x20 0x00 return
+        }
+
+        #define macro MAIN() = takes(0) returns(0) {
+            TEST(0x01)
+        }
+    "#;
+
+    // Parse tokens
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    // Should fail here
+    parser.parse().unwrap();
+}
+
+#[test]
+#[should_panic]
+fn test_breaking_param_commas() {
+    let source: &str = r#"
+        // Here we have a macro invocation directly in the parameter list - this should fail
+        #define macro TEST(t,,) = takes(0) returns(0) {
+            <value> 0x00 mstore
+            0x20 0x00 return
+        }
+
+        #define macro MAIN() = takes(0) returns(0) {
+            TEST(0x01)
+        }
+    "#;
+
+    // Parse tokens
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    // Should fail here
+    parser.parse().unwrap();
+}


### PR DESCRIPTION
## Overview

Previously, passing an unacceptable token as a parameter to a macro would cause the parser to loop indefinitely as it tried to find a closing parenthesis.

This pr introduces a check in parameter parsing that makes sure some sort of parameter was parsed (type or name), otherwise we have an invalid token.

Closes #178