### PR TITLE
feat(huff_codegen): `__RIGHTPAD` builtin

### DIFF
--- a/huff_lexer/tests/builtins.rs
+++ b/huff_lexer/tests/builtins.rs
@@ -4,8 +4,15 @@ use std::ops::Deref;
 
 #[test]
 fn parses_builtin_function_in_macro_body() {
-    let builtin_funcs =
-        ["__codesize", "__tablesize", "__tablestart", "__FUNC_SIG", "__EVENT_HASH", "__ERROR"];
+    let builtin_funcs = [
+        "__codesize",
+        "__tablesize",
+        "__tablestart",
+        "__FUNC_SIG",
+        "__EVENT_HASH",
+        "__ERROR",
+        "__RIGHTPAD",
+    ];
 
     for builtin in builtin_funcs {
         let source = &format!(
@@ -70,8 +77,15 @@ fn parses_builtin_function_in_macro_body() {
 #[test]
 #[should_panic]
 fn fails_to_parse_builtin_outside_macro_body() {
-    let builtin_funcs =
-        ["__codesize", "__tablesize", "__tablestart", "__FUNC_SIG", "__EVENT_HASH", "__ERROR"];
+    let builtin_funcs = [
+        "__codesize",
+        "__tablesize",
+        "__tablestart",
+        "__FUNC_SIG",
+        "__EVENT_HASH",
+        "__ERROR",
+        "__RIGHTPAD",
+    ];
 
     for builtin in builtin_funcs {
         let source = &format!("{}(MAIN)", builtin);

--- a/huff_parser/tests/labels.rs
+++ b/huff_parser/tests/labels.rs
@@ -198,6 +198,7 @@ pub fn builtins_under_labels() {
             __codesize(SMALL_MACRO)
             __FUNC_SIG(myFunc)
             __ERROR(TestError)
+            __RIGHTPAD(0xBB)
     }
     "#;
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
@@ -309,6 +310,25 @@ pub fn builtins_under_labels() {
                             Span { start: 477, end: 486, file: None },
                         ]),
                     },
+                    Statement {
+                        ty: StatementType::BuiltinFunctionCall(BuiltinFunctionCall {
+                            kind: BuiltinFunctionKind::RightPad,
+                            args: vec![Argument {
+                                arg_type: None,
+                                name: Some(String::from("bb")),
+                                indexed: false,
+                                span: AstSpan(vec![Span { start: 513, end: 515, file: None }]),
+                            }],
+                            span: AstSpan(vec![
+                                Span { start: 500, end: 510, file: None },
+                                Span { start: 513, end: 515, file: None },
+                            ]),
+                        }),
+                        span: AstSpan(vec![
+                            Span { start: 500, end: 510, file: None },
+                            Span { start: 513, end: 515, file: None },
+                        ]),
+                    },
                 ],
                 span: AstSpan(vec![
                     Span { start: 307, end: 315, file: None },
@@ -322,6 +342,8 @@ pub fn builtins_under_labels() {
                     Span { start: 449, end: 455, file: None },
                     Span { start: 469, end: 476, file: None },
                     Span { start: 477, end: 486, file: None },
+                    Span { start: 500, end: 510, file: None },
+                    Span { start: 513, end: 515, file: None },
                 ]),
             }),
             span: AstSpan(vec![
@@ -336,6 +358,8 @@ pub fn builtins_under_labels() {
                 Span { start: 449, end: 455, file: None },
                 Span { start: 469, end: 476, file: None },
                 Span { start: 477, end: 486, file: None },
+                Span { start: 500, end: 510, file: None },
+                Span { start: 513, end: 515, file: None },
             ]),
         }],
         takes: 3,
@@ -378,7 +402,11 @@ pub fn builtins_under_labels() {
             Span { start: 476, end: 477, file: None },
             Span { start: 477, end: 486, file: None },
             Span { start: 486, end: 487, file: None },
-            Span { start: 492, end: 493, file: None },
+            Span { start: 500, end: 510, file: None },
+            Span { start: 510, end: 511, file: None },
+            Span { start: 513, end: 515, file: None },
+            Span { start: 515, end: 516, file: None },
+            Span { start: 521, end: 522, file: None },
         ]),
         outlined: false,
     };

--- a/huff_utils/src/ast.rs
+++ b/huff_utils/src/ast.rs
@@ -676,6 +676,8 @@ pub enum BuiltinFunctionKind {
     EventHash,
     /// Error selector function
     Error,
+    /// Rightpad function
+    RightPad,
 }
 
 impl From<String> for BuiltinFunctionKind {
@@ -687,6 +689,7 @@ impl From<String> for BuiltinFunctionKind {
             "__FUNC_SIG" => BuiltinFunctionKind::FunctionSignature,
             "__EVENT_HASH" => BuiltinFunctionKind::EventHash,
             "__ERROR" => BuiltinFunctionKind::Error,
+            "__RIGHTPAD" => BuiltinFunctionKind::RightPad,
             _ => panic!("Invalid Builtin Function Kind"), /* This should never be reached,
                                                            * builtins are validated with a
                                                            * `try_from` call in the lexer. */
@@ -705,6 +708,7 @@ impl TryFrom<&String> for BuiltinFunctionKind {
             "__FUNC_SIG" => Ok(BuiltinFunctionKind::FunctionSignature),
             "__EVENT_HASH" => Ok(BuiltinFunctionKind::EventHash),
             "__ERROR" => Ok(BuiltinFunctionKind::Error),
+            "__RIGHTPAD" => Ok(BuiltinFunctionKind::RightPad),
             _ => Err(()),
         }
     }


### PR DESCRIPTION
## Overview

Adds a new builtin, `__RIGHTPAD(n)` to assist with pushing right-padded bytes to the stack.

#### Syntax
```
#define macro MAIN() = takes (0) returns (0) {
    // a57b000000000000000000000000000000000000000000000000000000000000
    __RIGHTPAD(0xa57b) 

    // 48656c6c6f2c20576f726c642100000000000000000000000000000000000000
    __RIGHTPAD(0x48656c6c6f2c20576f726c6421)

    // 06d6f6f736500000000000000000000000000000000000000000000000000000
    __RIGHTPAD(0x06d6f6f7365)
}
```

closes #184 