### PR TITLE
fix: Opcodes in Macro Invocations

### DIFF
--- a/huff_codegen/src/irgen/arg_calls.rs
+++ b/huff_codegen/src/irgen/arg_calls.rs
@@ -147,7 +147,6 @@ pub fn bubble_arg_call(
                                 *offset += 3;
                             }
                         }
-
                     }
                 }
             } else {

--- a/huff_core/src/cache.rs
+++ b/huff_core/src/cache.rs
@@ -31,7 +31,7 @@ pub fn resolve_existing_artifacts(
         files.iter().map(|f| (f.path.clone().to_lowercase(), Arc::clone(f))).collect();
 
     // If outputdir is not specified, use the default "./artifacts/" directory
-    let output_dir = (!output.0.is_empty()).then_some(&*output.0).unwrap_or("./artifacts");
+    let output_dir = if !output.0.is_empty() { &*output.0 } else { "./artifacts" };
 
     // For each file, check if the artifact file exists at the location
     tracing::debug!(target: "core", "Traversing output directory {}", output_dir);

--- a/huff_core/tests/macro_invoc_args.rs
+++ b/huff_core/tests/macro_invoc_args.rs
@@ -2,6 +2,7 @@ use huff_codegen::Codegen;
 use huff_lexer::Lexer;
 use huff_parser::Parser;
 use huff_utils::prelude::*;
+use std::str::FromStr;
 
 #[test]
 fn test_opcode_macro_args() {
@@ -35,4 +36,42 @@ fn test_opcode_macro_args() {
 
     // Check the bytecode
     assert_eq!(bytecode.to_lowercase(), expected_bytecode.to_lowercase());
+}
+
+#[test]
+fn test_all_opcodes_in_macro_args() {
+    for o in OPCODES {
+        let source = format!(
+            r#"
+            #define macro RETURN1(zero) = takes(1) returns(0) {{
+                <zero>
+            }}
+
+            #define macro MAIN() = takes(0) returns(0) {{
+                RETURN1({})
+            }}
+        "#,
+            o
+        );
+
+        // Lex + Parse
+        let flattened_source = FullFileSource { source: &source, file: None, spans: vec![] };
+        let lexer = Lexer::new(flattened_source);
+        let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+        let mut parser = Parser::new(tokens, None);
+        let mut contract = parser.parse().unwrap();
+        contract.derive_storage_pointers();
+
+        // Create main and constructor bytecode
+        let main_bytecode = Codegen::generate_main_bytecode(&contract).unwrap();
+
+        // Full expected bytecode output (generated from huffc) (placed here as a reference)
+        let expected_bytecode = format!("60088060093d393df360ff{}", Opcode::from_str(o).unwrap());
+
+        // Create bytecode
+        let bytecode = format!("60088060093d393df360ff{}", main_bytecode);
+
+        // Check the bytecode
+        assert_eq!(bytecode.to_lowercase(), expected_bytecode.to_lowercase());
+    }
 }

--- a/huff_core/tests/macro_invoc_args.rs
+++ b/huff_core/tests/macro_invoc_args.rs
@@ -1,0 +1,38 @@
+use huff_codegen::Codegen;
+use huff_lexer::Lexer;
+use huff_parser::Parser;
+use huff_utils::prelude::*;
+
+#[test]
+fn test_opcode_macro_args() {
+    let source = r#"
+        #define macro RETURN1(zero) = takes(1) returns(0) {
+            <zero> mstore
+            0x20 <zero> return
+        }
+
+        #define macro MAIN() = takes(0) returns(0) {
+            RETURN1(returndatasize)
+        }
+    "#;
+
+    // Lex + Parse
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // Create main and constructor bytecode
+    let main_bytecode = Codegen::generate_main_bytecode(&contract).unwrap();
+
+    // Full expected bytecode output (generated from huffc) (placed here as a reference)
+    let expected_bytecode = "60088060093d393df360ff3d5260203df3";
+
+    // Create bytecode
+    let bytecode = format!("60088060093d393df360ff{}", main_bytecode);
+
+    // Check the bytecode
+    assert_eq!(bytecode.to_lowercase(), expected_bytecode.to_lowercase());
+}

--- a/huff_parser/tests/macro.rs
+++ b/huff_parser/tests/macro.rs
@@ -605,6 +605,45 @@ fn macro_invocation_with_arg_call() {
     assert_eq!(parser.current_token.kind, TokenKind::Eof);
 }
 
+
+#[test]
+fn test_macro_opcode_arguments() {
+    let source = r#"
+    #define macro MAIN() = takes(0) returns(0) {
+        RETURN1(returndatasize)
+    }
+    "#;
+
+    // Parse tokens
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    // Grab the first macro
+    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let expected = MacroDefinition {
+        name: "MAIN".to_string(),
+        parameters: vec![],
+        statements: vec![
+            Statement {
+                ty: StatementType::MacroInvocation(MacroInvocation {
+                    macro_name: "RETURN1".to_string(),
+                    args: vec![MacroArg::Ident("returndatasize".to_string())],
+                    span: AstSpan(vec![Span { start: 58, end: 65, file: None }, Span { start: 65, end: 66, file: None }, Span { start: 66, end: 80, file: None }, Span { start: 80, end: 81, file: None }]),
+                }),
+                span: AstSpan(vec![Span { start: 58, end: 65, file: None }, Span { start: 65, end: 66, file: None }, Span { start: 66, end: 80, file: None }, Span { start: 80, end: 81, file: None }]),
+            },
+        ],
+        takes: 0,
+        returns: 0,
+        span: AstSpan(vec![Span { start: 5, end: 12, file: None }, Span { start: 13, end: 18, file: None }, Span { start: 19, end: 23, file: None }, Span { start: 23, end: 24, file: None }, Span { start: 24, end: 25, file: None }, Span { start: 26, end: 27, file: None }, Span { start: 28, end: 33, file: None }, Span { start: 33, end: 34, file: None }, Span { start: 34, end: 35, file: None }, Span { start: 35, end: 36, file: None }, Span { start: 37, end: 44, file: None }, Span { start: 44, end: 45, file: None }, Span { start: 45, end: 46, file: None }, Span { start: 46, end: 47, file: None }, Span { start: 48, end: 49, file: None }, Span { start: 58, end: 65, file: None }, Span { start: 65, end: 66, file: None }, Span { start: 66, end: 80, file: None }, Span { start: 80, end: 81, file: None }, Span { start: 86, end: 87, file: None }]),
+        outlined: false,
+    };
+    assert_eq!(macro_definition, expected);
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
 #[test]
 fn macro_with_builtin_fn_call() {
     // Not valid source, just for testing

--- a/huff_parser/tests/macro.rs
+++ b/huff_parser/tests/macro.rs
@@ -605,7 +605,6 @@ fn macro_invocation_with_arg_call() {
     assert_eq!(parser.current_token.kind, TokenKind::Eof);
 }
 
-
 #[test]
 fn test_macro_opcode_arguments() {
     let source = r#"
@@ -625,19 +624,48 @@ fn test_macro_opcode_arguments() {
     let expected = MacroDefinition {
         name: "MAIN".to_string(),
         parameters: vec![],
-        statements: vec![
-            Statement {
-                ty: StatementType::MacroInvocation(MacroInvocation {
-                    macro_name: "RETURN1".to_string(),
-                    args: vec![MacroArg::Ident("returndatasize".to_string())],
-                    span: AstSpan(vec![Span { start: 58, end: 65, file: None }, Span { start: 65, end: 66, file: None }, Span { start: 66, end: 80, file: None }, Span { start: 80, end: 81, file: None }]),
-                }),
-                span: AstSpan(vec![Span { start: 58, end: 65, file: None }, Span { start: 65, end: 66, file: None }, Span { start: 66, end: 80, file: None }, Span { start: 80, end: 81, file: None }]),
-            },
-        ],
+        statements: vec![Statement {
+            ty: StatementType::MacroInvocation(MacroInvocation {
+                macro_name: "RETURN1".to_string(),
+                args: vec![MacroArg::Ident("returndatasize".to_string())],
+                span: AstSpan(vec![
+                    Span { start: 58, end: 65, file: None },
+                    Span { start: 65, end: 66, file: None },
+                    Span { start: 66, end: 80, file: None },
+                    Span { start: 80, end: 81, file: None },
+                ]),
+            }),
+            span: AstSpan(vec![
+                Span { start: 58, end: 65, file: None },
+                Span { start: 65, end: 66, file: None },
+                Span { start: 66, end: 80, file: None },
+                Span { start: 80, end: 81, file: None },
+            ]),
+        }],
         takes: 0,
         returns: 0,
-        span: AstSpan(vec![Span { start: 5, end: 12, file: None }, Span { start: 13, end: 18, file: None }, Span { start: 19, end: 23, file: None }, Span { start: 23, end: 24, file: None }, Span { start: 24, end: 25, file: None }, Span { start: 26, end: 27, file: None }, Span { start: 28, end: 33, file: None }, Span { start: 33, end: 34, file: None }, Span { start: 34, end: 35, file: None }, Span { start: 35, end: 36, file: None }, Span { start: 37, end: 44, file: None }, Span { start: 44, end: 45, file: None }, Span { start: 45, end: 46, file: None }, Span { start: 46, end: 47, file: None }, Span { start: 48, end: 49, file: None }, Span { start: 58, end: 65, file: None }, Span { start: 65, end: 66, file: None }, Span { start: 66, end: 80, file: None }, Span { start: 80, end: 81, file: None }, Span { start: 86, end: 87, file: None }]),
+        span: AstSpan(vec![
+            Span { start: 5, end: 12, file: None },
+            Span { start: 13, end: 18, file: None },
+            Span { start: 19, end: 23, file: None },
+            Span { start: 23, end: 24, file: None },
+            Span { start: 24, end: 25, file: None },
+            Span { start: 26, end: 27, file: None },
+            Span { start: 28, end: 33, file: None },
+            Span { start: 33, end: 34, file: None },
+            Span { start: 34, end: 35, file: None },
+            Span { start: 35, end: 36, file: None },
+            Span { start: 37, end: 44, file: None },
+            Span { start: 44, end: 45, file: None },
+            Span { start: 45, end: 46, file: None },
+            Span { start: 46, end: 47, file: None },
+            Span { start: 48, end: 49, file: None },
+            Span { start: 58, end: 65, file: None },
+            Span { start: 65, end: 66, file: None },
+            Span { start: 66, end: 80, file: None },
+            Span { start: 80, end: 81, file: None },
+            Span { start: 86, end: 87, file: None },
+        ]),
         outlined: false,
     };
     assert_eq!(macro_definition, expected);

--- a/huff_utils/src/evm.rs
+++ b/huff_utils/src/evm.rs
@@ -302,15 +302,13 @@ pub static OPCODES_MAP: phf::Map<&'static str, Opcode> = phf_map! {
 /// EVM Opcodes
 /// References <https://evm.codes>
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, EnumString)]
+#[strum(serialize_all = "lowercase")]
 pub enum Opcode {
     /// Halts execution.
-    #[strum(serialize = "stop")]
     Stop,
     /// Addition operation
-    #[strum(serialize = "add")]
     Add,
     /// Multiplication Operation
-    #[strum(serialize = "mul")]
     Mul,
     /// Subtraction Operation
     Sub,


### PR DESCRIPTION
## Overview

Fixes failing to parse idents in macro invocations as opcodes.

For example, invoking a macro with an opcode like: `MYMACRO(returndatasize)` would fail to compile since the `returndatasize` ident was parsed as a label instead of as an opcode.

Also fixes the `Opcode::from(&str)` impl by strum. Note: In another pr we should move away from the custom maps from opcode enum  variants to string and use this new strum impl.

## Checklist

- [x] Parses Opcodes
- [x] Tests Broken Example
- [x] Test All Opcodes