### PR TITLE
fix(huff_codegen): Constants as Macro Args

### DIFF
--- a/huff_codegen/src/irgen/arg_calls.rs
+++ b/huff_codegen/src/irgen/arg_calls.rs
@@ -121,31 +121,25 @@ pub fn bubble_arg_call(
                             *offset += push_bytes.len() / 2;
                             tracing::info!(target: "codegen", "OFFSET: {}, PUSH BYTES: {:?}", offset, push_bytes);
                             bytes.push((starting_offset, Bytes(push_bytes)));
+                        } else if let Ok(o) = Opcode::from_str(iden) {
+                            tracing::debug!(target: "codegen", "Found Opcode: {}", o);
+                            let b = Bytes(o.to_string());
+                            *offset += b.0.len() / 2;
+                            bytes.push((starting_offset, b));
                         } else {
-                            // Can be an Opcode, otherwise, it's a label
-                            match Opcode::from_str(iden) {
-                                Ok(o) => {
-                                    tracing::debug!(target: "codegen", "Found Opcode: {}", o);
-                                    let b = Bytes(o.to_string());
-                                    *offset += b.0.len() / 2;
-                                    bytes.push((starting_offset, b));
-                                }
-                                Err(_) => {
-                                    tracing::debug!(target: "codegen", "Found Label Call: {}", iden);
+                            tracing::debug!(target: "codegen", "Found Label Call: {}", iden);
 
-                                    // This should be equivalent to a label call.
-                                    bytes.push((*offset, Bytes(format!("{}xxxx", Opcode::Push2))));
-                                    jump_table.insert(
-                                        *offset,
-                                        vec![Jump {
-                                            label: iden.to_owned(),
-                                            bytecode_index: 0,
-                                            span: macro_invoc.1.span.clone(),
-                                        }],
-                                    );
-                                    *offset += 3;
-                                }
-                            }
+                            // This should be equivalent to a label call.
+                            bytes.push((*offset, Bytes(format!("{}xxxx", Opcode::Push2))));
+                            jump_table.insert(
+                                *offset,
+                                vec![Jump {
+                                    label: iden.to_owned(),
+                                    bytecode_index: 0,
+                                    span: macro_invoc.1.span.clone(),
+                                }],
+                            );
+                            *offset += 3;
                         }
                     }
                 }

--- a/huff_codegen/src/irgen/arg_calls.rs
+++ b/huff_codegen/src/irgen/arg_calls.rs
@@ -147,7 +147,6 @@ pub fn bubble_arg_call(
                                 *offset += 3;
                             }
                         }
-
                     }
                 }
             } else {

--- a/huff_codegen/src/irgen/arg_calls.rs
+++ b/huff_codegen/src/irgen/arg_calls.rs
@@ -21,39 +21,8 @@ pub fn bubble_arg_call(
 ) -> Result<(), CodegenError> {
     let starting_offset = *offset;
 
-    // Check Constant Definitions
-    if let Some(constant) =
-        contract.constants.borrow().iter().find(|const_def| const_def.name.eq(arg_name))
-    {
-        tracing::info!(target: "codegen", "ARGCALL IS CONSTANT: {:?}", constant);
-        let push_bytes = match &constant.value {
-            ConstVal::Literal(l) => {
-                let hex_literal: String = bytes32_to_string(l, false);
-                format!("{:02x}{}", 95 + hex_literal.len() / 2, hex_literal)
-            }
-            ConstVal::FreeStoragePointer(fsp) => {
-                // If this is reached in codegen stage,
-                // `derive_storage_pointers`
-                // method was not called on the AST.
-                tracing::error!(target: "codegen", "STORAGE POINTERS INCORRECTLY DERIVED FOR \"{:?}\"", fsp);
-                return Err(CodegenError {
-                    kind: CodegenErrorKind::StoragePointersNotDerived,
-                    span: AstSpan(vec![]),
-                    token: None,
-                })
-            }
-        };
-        *offset += push_bytes.len() / 2;
-        tracing::info!(target: "codegen", "OFFSET: {}, PUSH BYTES: {:?}", offset, push_bytes);
-        bytes.push((starting_offset, Bytes(push_bytes)));
-    } else if let Ok(o) = Opcode::from_str(arg_name) {
-        // Check Opcode Definition
-        let b = Bytes(o.to_string());
-        *offset += b.0.len() / 2;
-        tracing::info!(target: "codegen", "RECURSE_BYTECODE ARG CALL FOUND OPCODE: {:?}", b);
-        bytes.push((starting_offset, b));
-    } else if let Some(macro_invoc) = mis.last() {
-        // Literal & Arg Call Check
+    if let Some(macro_invoc) = mis.last() {
+        // Literal, Ident & Arg Call Check
         // First get this arg_nam position in the macro definition params
         if let Some(pos) = macro_def
             .parameters
@@ -124,27 +93,58 @@ pub fn bubble_arg_call(
                     MacroArg::Ident(iden) => {
                         tracing::debug!(target: "codegen", "Found MacroArg::Ident IN \"{}\" Macro Invocation: \"{}\"!", macro_invoc.1.macro_name, iden);
 
-                        // Can be an opcode, otherwise, it's a label
-                        match Opcode::from_str(iden) {
-                            Ok(o) => {
-                                tracing::debug!(target: "codegen", "Found Opcode: {}", o);
-                                let b = Bytes(o.to_string());
-                                *offset += b.0.len() / 2;
-                                tracing::info!(target: "codegen", "Found : {:?}", b);
-                                bytes.push((starting_offset, b));
-                            }
-                            Err(_) => {
-                                // This should be equivalent to a label call.
-                                bytes.push((*offset, Bytes(format!("{}xxxx", Opcode::Push2))));
-                                jump_table.insert(
-                                    *offset,
-                                    vec![Jump {
-                                        label: iden.to_owned(),
-                                        bytecode_index: 0,
-                                        span: macro_invoc.1.span.clone(),
-                                    }],
-                                );
-                                *offset += 3;
+                        // Check for a constant first
+                        if let Some(constant) = contract
+                            .constants
+                            .borrow()
+                            .iter()
+                            .find(|const_def| const_def.name.eq(iden))
+                        {
+                            tracing::info!(target: "codegen", "ARGCALL IS CONSTANT: {:?}", constant);
+                            let push_bytes = match &constant.value {
+                                ConstVal::Literal(l) => {
+                                    let hex_literal: String = bytes32_to_string(l, false);
+                                    format!("{:02x}{}", 95 + hex_literal.len() / 2, hex_literal)
+                                }
+                                ConstVal::FreeStoragePointer(fsp) => {
+                                    // If this is reached in codegen stage,
+                                    // `derive_storage_pointers`
+                                    // method was not called on the AST.
+                                    tracing::error!(target: "codegen", "STORAGE POINTERS INCORRECTLY DERIVED FOR \"{:?}\"", fsp);
+                                    return Err(CodegenError {
+                                        kind: CodegenErrorKind::StoragePointersNotDerived,
+                                        span: AstSpan(vec![]),
+                                        token: None,
+                                    })
+                                }
+                            };
+                            *offset += push_bytes.len() / 2;
+                            tracing::info!(target: "codegen", "OFFSET: {}, PUSH BYTES: {:?}", offset, push_bytes);
+                            bytes.push((starting_offset, Bytes(push_bytes)));
+                        } else {
+                            // Can be an Opcode, otherwise, it's a label
+                            match Opcode::from_str(iden) {
+                                Ok(o) => {
+                                    tracing::debug!(target: "codegen", "Found Opcode: {}", o);
+                                    let b = Bytes(o.to_string());
+                                    *offset += b.0.len() / 2;
+                                    bytes.push((starting_offset, b));
+                                }
+                                Err(_) => {
+                                    tracing::debug!(target: "codegen", "Found Label Call: {}", iden);
+
+                                    // This should be equivalent to a label call.
+                                    bytes.push((*offset, Bytes(format!("{}xxxx", Opcode::Push2))));
+                                    jump_table.insert(
+                                        *offset,
+                                        vec![Jump {
+                                            label: iden.to_owned(),
+                                            bytecode_index: 0,
+                                            span: macro_invoc.1.span.clone(),
+                                        }],
+                                    );
+                                    *offset += 3;
+                                }
                             }
                         }
                     }

--- a/huff_core/src/cache.rs
+++ b/huff_core/src/cache.rs
@@ -31,7 +31,7 @@ pub fn resolve_existing_artifacts(
         files.iter().map(|f| (f.path.clone().to_lowercase(), Arc::clone(f))).collect();
 
     // If outputdir is not specified, use the default "./artifacts/" directory
-    let output_dir = (!output.0.is_empty()).then_some(&*output.0).unwrap_or("./artifacts");
+    let output_dir = if !output.0.is_empty() { &*output.0 } else { "./artifacts" };
 
     // For each file, check if the artifact file exists at the location
     tracing::debug!(target: "core", "Traversing output directory {}", output_dir);

--- a/huff_core/tests/macro_invoc_args.rs
+++ b/huff_core/tests/macro_invoc_args.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 #[test]
 fn test_opcode_macro_args() {
     let source = r#"
-        #define macro RETURN1(zero) = takes(1) returns(0) {
+        #define macro RETURN1(zero) = takes(0) returns(0) {
             <zero> mstore
             0x20 <zero> return
         }
@@ -43,7 +43,7 @@ fn test_all_opcodes_in_macro_args() {
     for o in OPCODES {
         let source = format!(
             r#"
-            #define macro RETURN1(zero) = takes(1) returns(0) {{
+            #define macro RETURN1(zero) = takes(0) returns(0) {{
                 <zero>
             }}
 
@@ -81,12 +81,163 @@ fn test_constant_macro_arg() {
     let source = r#"
             #define constant A = 0x02
 
-            #define macro RETURN1(zero) = takes(1) returns(0) {
+            #define macro RETURN1(zero) = takes(0) returns(0) {
                 <zero>
             }
 
             #define macro MAIN() = takes(0) returns(0) {
                 RETURN1(A)
+            }
+        "#;
+
+    // Lex + Parse
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // Create main and constructor bytecode
+    let main_bytecode = Codegen::generate_main_bytecode(&contract).unwrap();
+
+    // Full expected bytecode output (generated from huffc) (placed here as a reference)
+    let expected_bytecode = "60088060093d393df360ff6002";
+
+    // Create bytecode
+    let bytecode = format!("60088060093d393df360ff{}", main_bytecode);
+
+    // Check the bytecode
+    assert_eq!(bytecode.to_lowercase(), expected_bytecode.to_lowercase());
+}
+
+#[test]
+fn test_bubbled_label_call_macro_arg() {
+    let source = r#"
+            #define macro MACRO_A(zero) = takes(0) returns(0) {
+                MACRO_B(<zero>)
+            }
+
+            #define macro MACRO_B(zero) = takes(0) returns(0) {
+                <zero>
+            }
+
+            #define macro MAIN() = takes(0) returns(0) {
+                label:
+                    MACRO_A(label)
+            }
+        "#;
+
+    // Lex + Parse
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // Create main and constructor bytecode
+    let main_bytecode = Codegen::generate_main_bytecode(&contract).unwrap();
+
+    // Full expected bytecode output (generated from huffc) (placed here as a reference)
+    let expected_bytecode = "60088060093d393df360ff5b610000";
+
+    // Create bytecode
+    let bytecode = format!("60088060093d393df360ff{}", main_bytecode);
+
+    // Check the bytecode
+    assert_eq!(bytecode.to_lowercase(), expected_bytecode.to_lowercase());
+}
+
+#[test]
+fn test_bubbled_literal_macro_arg() {
+    let source = r#"
+            #define macro MACRO_A(zero) = takes(0) returns(0) {
+                MACRO_B(<zero>)
+            }
+
+            #define macro MACRO_B(zero) = takes(0) returns(0) {
+                <zero>
+            }
+
+            #define macro MAIN() = takes(0) returns(0) {
+                MACRO_A(0x420)
+            }
+        "#;
+
+    // Lex + Parse
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // Create main and constructor bytecode
+    let main_bytecode = Codegen::generate_main_bytecode(&contract).unwrap();
+
+    // Full expected bytecode output (generated from huffc) (placed here as a reference)
+    let expected_bytecode = "60088060093d393df360ff610420";
+
+    // Create bytecode
+    let bytecode = format!("60088060093d393df360ff{}", main_bytecode);
+
+    // Check the bytecode
+    assert_eq!(bytecode.to_lowercase(), expected_bytecode.to_lowercase());
+}
+
+#[test]
+fn test_bubbled_opcode_macro_arg() {
+    let source = r#"
+            #define macro MACRO_A(zero) = takes(0) returns(0) {
+                MACRO_B(<zero>)
+            }
+
+            #define macro MACRO_B(zero) = takes(0) returns(0) {
+                <zero>
+            }
+
+            #define macro MAIN() = takes(0) returns(0) {
+                MACRO_A(returndatasize)
+            }
+        "#;
+
+    // Lex + Parse
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // Create main and constructor bytecode
+    let main_bytecode = Codegen::generate_main_bytecode(&contract).unwrap();
+
+    // Full expected bytecode output (generated from huffc) (placed here as a reference)
+    let expected_bytecode = "60088060093d393df360ff3d";
+
+    // Create bytecode
+    let bytecode = format!("60088060093d393df360ff{}", main_bytecode);
+
+    // Check the bytecode
+    assert_eq!(bytecode.to_lowercase(), expected_bytecode.to_lowercase());
+}
+
+#[test]
+fn test_bubbled_constant_macro_arg() {
+    let source = r#"
+            #define constant A = 0x02
+
+            #define macro MACRO_A(zero) = takes(0) returns(0) {
+                MACRO_B(<zero>)
+            }
+
+            #define macro MACRO_B(zero) = takes(0) returns(0) {
+                <zero>
+            }
+
+            #define macro MAIN() = takes(0) returns(0) {
+                MACRO_A(A)
             }
         "#;
 

--- a/huff_core/tests/macro_invoc_args.rs
+++ b/huff_core/tests/macro_invoc_args.rs
@@ -75,3 +75,38 @@ fn test_all_opcodes_in_macro_args() {
         assert_eq!(bytecode.to_lowercase(), expected_bytecode.to_lowercase());
     }
 }
+
+#[test]
+fn test_constant_macro_arg() {
+    let source = r#"
+            #define constant A = 0x02
+
+            #define macro RETURN1(zero) = takes(1) returns(0) {
+                <zero>
+            }
+
+            #define macro MAIN() = takes(0) returns(0) {
+                RETURN1(A)
+            }
+        "#;
+
+    // Lex + Parse
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // Create main and constructor bytecode
+    let main_bytecode = Codegen::generate_main_bytecode(&contract).unwrap();
+
+    // Full expected bytecode output (generated from huffc) (placed here as a reference)
+    let expected_bytecode = "60088060093d393df360ff6002";
+
+    // Create bytecode
+    let bytecode = format!("60088060093d393df360ff{}", main_bytecode);
+
+    // Check the bytecode
+    assert_eq!(bytecode.to_lowercase(), expected_bytecode.to_lowercase());
+}

--- a/huff_core/tests/macro_invoc_args.rs
+++ b/huff_core/tests/macro_invoc_args.rs
@@ -2,6 +2,7 @@ use huff_codegen::Codegen;
 use huff_lexer::Lexer;
 use huff_parser::Parser;
 use huff_utils::prelude::*;
+use std::str::FromStr;
 
 #[test]
 fn test_opcode_macro_args() {
@@ -35,4 +36,42 @@ fn test_opcode_macro_args() {
 
     // Check the bytecode
     assert_eq!(bytecode.to_lowercase(), expected_bytecode.to_lowercase());
+}
+
+#[test]
+fn test_all_opcodes_in_macro_args() {
+    for o in OPCODES {
+        let source = format!(
+            r#"
+            #define macro RETURN1(zero) = takes(1) returns(0) {{
+                <zero>
+            }}
+
+            #define macro MAIN() = takes(0) returns(0) {{
+                RETURN1({})
+            }}
+        "#,
+            o
+        );
+
+        // Lex + Parse
+        let flattened_source = FullFileSource { source: &source, file: None, spans: vec![] };
+        let lexer = Lexer::new(flattened_source);
+        let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+        let mut parser = Parser::new(tokens, None);
+        let mut contract = parser.parse().unwrap();
+        contract.derive_storage_pointers();
+
+        // Create main and constructor bytecode
+        let main_bytecode = Codegen::generate_main_bytecode(&contract).unwrap();
+
+        // Full expected bytecode output (generated from huffc) (placed here as a reference)
+        let expected_bytecode = format!("60088060093d393df360ff{}", Opcode::from_str(o).unwrap());
+
+        // Create bytecode
+        let bytecode = format!("60088060093d393df360ff{}", main_bytecode);
+
+        // Check the bytecode
+        assert_eq!(bytecode.to_lowercase(), expected_bytecode.to_lowercase());
+    }
 }

--- a/huff_core/tests/macro_invoc_args.rs
+++ b/huff_core/tests/macro_invoc_args.rs
@@ -1,0 +1,38 @@
+use huff_codegen::Codegen;
+use huff_lexer::Lexer;
+use huff_parser::Parser;
+use huff_utils::prelude::*;
+
+#[test]
+fn test_opcode_macro_args() {
+    let source = r#"
+        #define macro RETURN1(zero) = takes(1) returns(0) {
+            <zero> mstore
+            0x20 <zero> return
+        }
+
+        #define macro MAIN() = takes(0) returns(0) {
+            RETURN1(returndatasize)
+        }
+    "#;
+
+    // Lex + Parse
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // Create main and constructor bytecode
+    let main_bytecode = Codegen::generate_main_bytecode(&contract).unwrap();
+
+    // Full expected bytecode output (generated from huffc) (placed here as a reference)
+    let expected_bytecode = "60088060093d393df360ff3d5260203df3";
+
+    // Create bytecode
+    let bytecode = format!("60088060093d393df360ff{}", main_bytecode);
+
+    // Check the bytecode
+    assert_eq!(bytecode.to_lowercase(), expected_bytecode.to_lowercase());
+}

--- a/huff_core/tests/parser_errors.rs
+++ b/huff_core/tests/parser_errors.rs
@@ -247,7 +247,7 @@ fn test_invalid_token_in_label_definition() {
 
 #[test]
 fn test_invalid_single_arg() {
-    for _ in [0..10_000] {
+    for _ in 0..10_000 {
         let random_char = rand::random::<u8>() as char;
         if random_char.is_numeric() ||
             !random_char.is_alphabetic() ||

--- a/huff_parser/tests/macro.rs
+++ b/huff_parser/tests/macro.rs
@@ -605,6 +605,45 @@ fn macro_invocation_with_arg_call() {
     assert_eq!(parser.current_token.kind, TokenKind::Eof);
 }
 
+
+#[test]
+fn test_macro_opcode_arguments() {
+    let source = r#"
+    #define macro MAIN() = takes(0) returns(0) {
+        RETURN1(returndatasize)
+    }
+    "#;
+
+    // Parse tokens
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    // Grab the first macro
+    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let expected = MacroDefinition {
+        name: "MAIN".to_string(),
+        parameters: vec![],
+        statements: vec![
+            Statement {
+                ty: StatementType::MacroInvocation(MacroInvocation {
+                    macro_name: "RETURN1".to_string(),
+                    args: vec![MacroArg::Ident("returndatasize".to_string())],
+                    span: AstSpan(vec![Span { start: 58, end: 65, file: None }, Span { start: 65, end: 66, file: None }, Span { start: 66, end: 80, file: None }, Span { start: 80, end: 81, file: None }]),
+                }),
+                span: AstSpan(vec![Span { start: 58, end: 65, file: None }, Span { start: 65, end: 66, file: None }, Span { start: 66, end: 80, file: None }, Span { start: 80, end: 81, file: None }]),
+            },
+        ],
+        takes: 0,
+        returns: 0,
+        span: AstSpan(vec![Span { start: 5, end: 12, file: None }, Span { start: 13, end: 18, file: None }, Span { start: 19, end: 23, file: None }, Span { start: 23, end: 24, file: None }, Span { start: 24, end: 25, file: None }, Span { start: 26, end: 27, file: None }, Span { start: 28, end: 33, file: None }, Span { start: 33, end: 34, file: None }, Span { start: 34, end: 35, file: None }, Span { start: 35, end: 36, file: None }, Span { start: 37, end: 44, file: None }, Span { start: 44, end: 45, file: None }, Span { start: 45, end: 46, file: None }, Span { start: 46, end: 47, file: None }, Span { start: 48, end: 49, file: None }, Span { start: 58, end: 65, file: None }, Span { start: 65, end: 66, file: None }, Span { start: 66, end: 80, file: None }, Span { start: 80, end: 81, file: None }, Span { start: 86, end: 87, file: None }]),
+        outlined: false,
+    };
+    assert_eq!(macro_definition, expected);
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}
+
 #[test]
 fn macro_with_builtin_fn_call() {
     // Not valid source, just for testing

--- a/huff_parser/tests/macro.rs
+++ b/huff_parser/tests/macro.rs
@@ -605,7 +605,6 @@ fn macro_invocation_with_arg_call() {
     assert_eq!(parser.current_token.kind, TokenKind::Eof);
 }
 
-
 #[test]
 fn test_macro_opcode_arguments() {
     let source = r#"
@@ -625,19 +624,48 @@ fn test_macro_opcode_arguments() {
     let expected = MacroDefinition {
         name: "MAIN".to_string(),
         parameters: vec![],
-        statements: vec![
-            Statement {
-                ty: StatementType::MacroInvocation(MacroInvocation {
-                    macro_name: "RETURN1".to_string(),
-                    args: vec![MacroArg::Ident("returndatasize".to_string())],
-                    span: AstSpan(vec![Span { start: 58, end: 65, file: None }, Span { start: 65, end: 66, file: None }, Span { start: 66, end: 80, file: None }, Span { start: 80, end: 81, file: None }]),
-                }),
-                span: AstSpan(vec![Span { start: 58, end: 65, file: None }, Span { start: 65, end: 66, file: None }, Span { start: 66, end: 80, file: None }, Span { start: 80, end: 81, file: None }]),
-            },
-        ],
+        statements: vec![Statement {
+            ty: StatementType::MacroInvocation(MacroInvocation {
+                macro_name: "RETURN1".to_string(),
+                args: vec![MacroArg::Ident("returndatasize".to_string())],
+                span: AstSpan(vec![
+                    Span { start: 58, end: 65, file: None },
+                    Span { start: 65, end: 66, file: None },
+                    Span { start: 66, end: 80, file: None },
+                    Span { start: 80, end: 81, file: None },
+                ]),
+            }),
+            span: AstSpan(vec![
+                Span { start: 58, end: 65, file: None },
+                Span { start: 65, end: 66, file: None },
+                Span { start: 66, end: 80, file: None },
+                Span { start: 80, end: 81, file: None },
+            ]),
+        }],
         takes: 0,
         returns: 0,
-        span: AstSpan(vec![Span { start: 5, end: 12, file: None }, Span { start: 13, end: 18, file: None }, Span { start: 19, end: 23, file: None }, Span { start: 23, end: 24, file: None }, Span { start: 24, end: 25, file: None }, Span { start: 26, end: 27, file: None }, Span { start: 28, end: 33, file: None }, Span { start: 33, end: 34, file: None }, Span { start: 34, end: 35, file: None }, Span { start: 35, end: 36, file: None }, Span { start: 37, end: 44, file: None }, Span { start: 44, end: 45, file: None }, Span { start: 45, end: 46, file: None }, Span { start: 46, end: 47, file: None }, Span { start: 48, end: 49, file: None }, Span { start: 58, end: 65, file: None }, Span { start: 65, end: 66, file: None }, Span { start: 66, end: 80, file: None }, Span { start: 80, end: 81, file: None }, Span { start: 86, end: 87, file: None }]),
+        span: AstSpan(vec![
+            Span { start: 5, end: 12, file: None },
+            Span { start: 13, end: 18, file: None },
+            Span { start: 19, end: 23, file: None },
+            Span { start: 23, end: 24, file: None },
+            Span { start: 24, end: 25, file: None },
+            Span { start: 26, end: 27, file: None },
+            Span { start: 28, end: 33, file: None },
+            Span { start: 33, end: 34, file: None },
+            Span { start: 34, end: 35, file: None },
+            Span { start: 35, end: 36, file: None },
+            Span { start: 37, end: 44, file: None },
+            Span { start: 44, end: 45, file: None },
+            Span { start: 45, end: 46, file: None },
+            Span { start: 46, end: 47, file: None },
+            Span { start: 48, end: 49, file: None },
+            Span { start: 58, end: 65, file: None },
+            Span { start: 65, end: 66, file: None },
+            Span { start: 66, end: 80, file: None },
+            Span { start: 80, end: 81, file: None },
+            Span { start: 86, end: 87, file: None },
+        ]),
         outlined: false,
     };
     assert_eq!(macro_definition, expected);

--- a/huff_utils/src/evm.rs
+++ b/huff_utils/src/evm.rs
@@ -302,15 +302,13 @@ pub static OPCODES_MAP: phf::Map<&'static str, Opcode> = phf_map! {
 /// EVM Opcodes
 /// References <https://evm.codes>
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, EnumString)]
+#[strum(serialize_all = "lowercase")]
 pub enum Opcode {
     /// Halts execution.
-    #[strum(serialize = "stop")]
     Stop,
     /// Addition operation
-    #[strum(serialize = "add")]
     Add,
     /// Multiplication Operation
-    #[strum(serialize = "mul")]
     Mul,
     /// Subtraction Operation
     Sub,


### PR DESCRIPTION
## Overview

Fixes an issue where constants weren't recognized if passed as a macro argument.

Branches off of #188, merge after that one.