### PR TITLE
feat(huff_cli): new runtime bytecode flag is added.

### DIFF
--- a/huff_cli/README.md
+++ b/huff_cli/README.md
@@ -25,6 +25,7 @@ OPTIONS:
     -n, --interactive                     Interactively input the constructor args
     -o, --output <OUTPUT>                 The output file path
     -p, --print                           Prints out to the terminal
+    -r, --bin-runtime                     Generate and log runtime bytecode
     -s, --source-path <SOURCE>            The contracts source path [default: ./contracts]
     -v, --verbose                         Verbose output
     -V, --version                         Print version information

--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -321,7 +321,13 @@ fn main() {
                     tracing::info!(target: "cli", "RE-EXPORTED INTERACTIVE ARTIFACTS");
                 }
                 match sources.len() {
-                    1 => print!("{}", artifacts[0].bytecode),
+                    1 => {
+                        if cli.bin_runtime {
+                            println!("\nbytecode: {}", artifacts[0].bytecode)
+                        } else {
+                            print!("{}", artifacts[0].bytecode)
+                        }
+                    }
                     _ => artifacts
                         .iter()
                         .for_each(|a| println!("\"{}\" bytecode: {}", a.file.path, a.bytecode)),
@@ -330,7 +336,13 @@ fn main() {
 
             if cli.bin_runtime {
                 match sources.len() {
-                    1 => print!("{}", artifacts[0].runtime),
+                    1 => {
+                        if cli.bytecode {
+                            println!("\nruntime: {}", artifacts[0].runtime)
+                        } else {
+                            print!("{}", artifacts[0].runtime)
+                        }
+                    }
                     _ => artifacts
                         .iter()
                         .for_each(|a| println!("\"{}\" runtime: {}", a.file.path, a.runtime)),

--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -63,6 +63,10 @@ struct Huff {
     #[clap(short = 'b', long = "bytecode")]
     bytecode: bool,
 
+    /// Generate and log runtime bytecode.
+    #[clap(short = 'r', long = "bin-runtime")]
+    bin_runtime: bool,
+
     /// Prints out to the terminal.
     #[clap(short = 'p', long = "print")]
     print: bool,
@@ -321,6 +325,15 @@ fn main() {
                     _ => artifacts
                         .iter()
                         .for_each(|a| println!("\"{}\" bytecode: {}", a.file.path, a.bytecode)),
+                }
+            }
+
+            if cli.bin_runtime {
+                match sources.len() {
+                    1 => print!("{}", artifacts[0].runtime),
+                    _ => artifacts
+                        .iter()
+                        .for_each(|a| println!("\"{}\" runtime: {}", a.file.path, a.runtime)),
                 }
             }
         }


### PR DESCRIPTION
## Overview

We added a new `huffc` flag `-r` or `--bin-runtime` that would only print the runtime bytecode.
