### PR TITLE
Fix obfuscated-if-else

### DIFF
--- a/huff_core/src/cache.rs
+++ b/huff_core/src/cache.rs
@@ -31,7 +31,7 @@ pub fn resolve_existing_artifacts(
         files.iter().map(|f| (f.path.clone().to_lowercase(), Arc::clone(f))).collect();
 
     // If outputdir is not specified, use the default "./artifacts/" directory
-    let output_dir = (!output.0.is_empty()).then_some(&*output.0).unwrap_or("./artifacts");
+    let output_dir = if !output.0.is_empty() { &*output.0 } else { "./artifacts" };
 
     // For each file, check if the artifact file exists at the location
     tracing::debug!(target: "core", "Traversing output directory {}", output_dir);


### PR DESCRIPTION
## Overview

I got the following clippy error when I tried to run it locally to contribute, so I fixed it.

```
$ cargo +nightly clippy --all --all-features -- -D clippy::obfuscated-if-else
(snip)
error: use of `.then_some(..).unwrap_or(..)` can be written more clearly with `if .. else ..`
  --> huff_core/src/cache.rs:34:22
   |
34 |     let output_dir = (!output.0.is_empty()).then_some(&*output.0).unwrap_or("./artifacts");
   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if (!output.0.is_empty()) { &*output.0 } else { "./artifacts" }`
   |
   = note: requested on the command line with `-D clippy::obfuscated-if-else`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#obfuscated_if_else

error: could not compile `huff_core` due to previous error
```


<!--
Thank you for creating a Pull Request!
Please provide a short description here and review the requirements below.
Bug fixes and new features should include tests.

Make sure to run these checks before opening a pr!
```sh
cargo check --all
cargo test --all --all-features
cargo +nightly fmt -- --check
cargo +nightly clippy --all --all-features -- -D warnings
```

Recommended method to auto format your code before pushing:
```sh
cargo +nightly fmt --all
```
-->
