### PR TITLE
feat(huff_core): Remapping Import Resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,9 @@ dependencies = [
  "strum",
  "strum_macros",
  "tiny-keccak",
+ "toml",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,5 @@
+[profile.default]
+optimizer = true
+remappings = [
+    "examples/=huff-examples/",
+]

--- a/huff_core/benches/huff_benchmark.rs
+++ b/huff_core/benches/huff_benchmark.rs
@@ -3,7 +3,7 @@ use huff_codegen::*;
 use huff_core::Compiler;
 use huff_lexer::*;
 use huff_parser::*;
-use huff_utils::prelude::*;
+use huff_utils::{files, prelude::*};
 use std::{path::PathBuf, sync::Arc};
 
 fn lex_erc20_from_source_benchmark(c: &mut Criterion) {
@@ -16,7 +16,8 @@ fn lex_erc20_from_source_benchmark(c: &mut Criterion) {
 
     // Recurse file deps + generate flattened source
     let file_source = file_sources.get(0).unwrap();
-    let recursed_file_source = Compiler::recurse_deps(Arc::clone(file_source)).unwrap();
+    let recursed_file_source =
+        Compiler::recurse_deps(Arc::clone(file_source), &files::Remapper::new("./")).unwrap();
     let flattened = FileSource::fully_flatten(Arc::clone(&recursed_file_source));
     let full_source = FullFileSource {
         source: &flattened.0,
@@ -43,7 +44,8 @@ fn parse_erc20_benchmark(c: &mut Criterion) {
 
     // Recurse file deps + generate flattened source
     let file_source = file_sources.get(0).unwrap();
-    let recursed_file_source = Compiler::recurse_deps(Arc::clone(file_source)).unwrap();
+    let recursed_file_source =
+        Compiler::recurse_deps(Arc::clone(file_source), &files::Remapper::new("./")).unwrap();
     let flattened = FileSource::fully_flatten(Arc::clone(&recursed_file_source));
     let full_source = FullFileSource {
         source: &flattened.0,
@@ -75,7 +77,8 @@ fn codegen_erc20_benchmark(c: &mut Criterion) {
 
     // Recurse file deps + generate flattened source
     let file_source = file_sources.get(0).unwrap();
-    let recursed_file_source = Compiler::recurse_deps(Arc::clone(file_source)).unwrap();
+    let recursed_file_source =
+        Compiler::recurse_deps(Arc::clone(file_source), &files::Remapper::new("./")).unwrap();
     let flattened = FileSource::fully_flatten(Arc::clone(&recursed_file_source));
     let full_source = FullFileSource {
         source: &flattened.0,
@@ -119,7 +122,7 @@ fn erc20_compilation_benchmark(c: &mut Criterion) {
 
         // Recurse file deps + generate flattened source
         let file_source = file_sources.get(0).unwrap();
-        let recursed_file_source = Compiler::recurse_deps(Arc::clone(file_source)).unwrap();
+        let recursed_file_source = Compiler::recurse_deps(Arc::clone(file_source), &files::Remapper::new("./")).unwrap();
         let flattened = FileSource::fully_flatten(Arc::clone(&recursed_file_source));
         let full_source = FullFileSource {
             source: &flattened.0,
@@ -159,7 +162,7 @@ fn erc721_compilation_benchmark(c: &mut Criterion) {
 
         // Recurse file deps + generate flattened source
         let file_source = file_sources.get(0).unwrap();
-        let recursed_file_source = Compiler::recurse_deps(Arc::clone(file_source)).unwrap();
+        let recursed_file_source = Compiler::recurse_deps(Arc::clone(file_source), &files::Remapper::new("./")).unwrap();
         let flattened = FileSource::fully_flatten(Arc::clone(&recursed_file_source));
         let full_source = FullFileSource {
             source: &flattened.0,

--- a/huff_core/src/lib.rs
+++ b/huff_core/src/lib.rs
@@ -335,7 +335,6 @@ impl<'a> Compiler<'a> {
         let mut parser = Parser::new(tokens, Some(file.path.clone()));
 
         // Parse into an AST
-        tracing::debug!(target: "core", "Core parsing \"{}\"", file.path);
         let parse_res = parser.parse().map_err(CompilerError::ParserError);
         let mut contract = parse_res?;
         contract.derive_storage_pointers();
@@ -343,7 +342,6 @@ impl<'a> Compiler<'a> {
         tracing::info!(target: "core", "PARSED CONTRACT [{}]", file.path);
 
         // Primary Bytecode Generation
-        // See huffc: https://github.com/huff-language/huffc/blob/2e5287afbfdf9cc977b204a4fd1e89c27375b040/src/compiler/processor.ts
         let mut cg = Codegen::new();
         let main_bytecode = match Codegen::generate_main_bytecode(&contract) {
             Ok(mb) => mb,
@@ -365,6 +363,8 @@ impl<'a> Compiler<'a> {
             }
         };
         tracing::info!(target: "core", "MAIN BYTECODE GENERATED [{}]", main_bytecode);
+
+        // Generate Constructor Bytecode
         let inputs = self.get_constructor_args();
         let constructor_bytecode = match Codegen::generate_constructor_bytecode(&contract) {
             Ok(mb) => mb,
@@ -395,10 +395,9 @@ impl<'a> Compiler<'a> {
                 "".to_string()
             }
         };
+        tracing::info!(target: "core", "CONSTRUCTOR BYTECODE GENERATED [{}]", constructor_bytecode);
 
         // Encode Constructor Arguments
-        tracing::info!(target: "core", "CONSTRUCTOR BYTECODE GENERATED [{}]", constructor_bytecode);
-        tracing::info!(target: "core", "ENCODING {} INPUTS", inputs.len());
         let encoded_inputs = Codegen::encode_constructor_args(inputs);
         tracing::info!(target: "core", "ENCODED {} INPUTS", encoded_inputs.len());
 

--- a/huff_core/src/lib.rs
+++ b/huff_core/src/lib.rs
@@ -479,16 +479,12 @@ impl<'a> Compiler<'a> {
             .into_iter()
             .map(|mut import| {
                 // Check for foundry toml remappings
-                tracing::debug!(target: "core", "core has remapper {:?}", remapper);
-                tracing::debug!(target: "core", "core import path {}", import);
-                tracing::debug!(target: "core", "Current dir: {:?}", std::env::current_dir());
                 match remapper.remap(&import) {
                     Some(remapped) => {
-                        tracing::debug!(target: "core", "core remapped path {}", import);
+                        tracing::debug!(target: "core", "REMAPPED IMPORT PATH \"{}\"", import);
                         import = remapped;
                     }
                     None => {
-                        tracing::debug!(target: "core", "core no remapped path {}", import);
                         import = FileSource::localize_file(&fs.path, &import)
                             .unwrap_or_default()
                             .replacen("contracts/contracts", "contracts", 1);

--- a/huff_core/tests/aliased_imports.rs
+++ b/huff_core/tests/aliased_imports.rs
@@ -3,21 +3,30 @@ use std::{str::FromStr, sync::Arc};
 use huff_core::Compiler;
 use huff_utils::prelude::*;
 
-// TODO: fix this test by writing broken inputs to a temp file?
-// #[test]
-// fn test_parses_foundry_aliased_imports() {
-//     println!("In env: {:?}", std::env::current_dir().unwrap());
-//     std::env::set_current_dir("../");
-//     println!("In env: {:?}", std::env::current_dir().unwrap());
-//     let import_bufs =
-//         vec![std::path::PathBuf::from_str("examples/erc20/contracts/ERC20.huff").unwrap()];
-//     let potentials = Compiler::fetch_sources(import_bufs)
-//         .into_iter()
-//         .collect::<Vec<Result<Arc<FileSource>, CompilerError<'_>>>>();
-//     for import in potentials {
-//         import.unwrap();
-//     }
-// }
+#[test]
+fn test_parses_foundry_aliased_imports() {
+    // Set the current directory to the root of huff-rs
+    std::env::set_current_dir("../").unwrap();
+
+    // Create a remapper at the root level
+    let remapper = Remapper::new("./");
+
+    // Use an aliased import defined in foundry.toml for "huff-examples" -> "examples"
+    let mut import_bufs =
+        vec![std::path::PathBuf::from_str("examples/erc20/contracts/ERC20.huff").unwrap()];
+
+    // Remap import bufs with `remapper`. Panic on failure.
+    import_bufs = import_bufs
+        .into_iter()
+        .map(|p| std::path::PathBuf::from(remapper.remap(p.to_str().unwrap()).unwrap()))
+        .collect();
+
+    // Fetch sources and unwrap errors
+    let _ = Compiler::fetch_sources(import_bufs)
+        .into_iter()
+        .map(|r| r.unwrap())
+        .collect::<Vec<Arc<FileSource>>>();
+}
 
 #[test]
 #[should_panic]

--- a/huff_core/tests/aliased_imports.rs
+++ b/huff_core/tests/aliased_imports.rs
@@ -33,10 +33,10 @@ fn test_parses_foundry_aliased_imports() {
 fn test_invalid_imports_break() {
     let import_bufs =
         vec![std::path::PathBuf::from_str("unaliased/erc20/contracts/ERC20.huff").unwrap()];
-    let potentials = Compiler::fetch_sources(import_bufs)
+
+    // Try to fetch sources
+    let _ = Compiler::fetch_sources(import_bufs)
         .into_iter()
-        .collect::<Vec<Result<Arc<FileSource>, CompilerError<'_>>>>();
-    for import in potentials {
-        import.unwrap();
-    }
+        .map(|r| r.unwrap())
+        .collect::<Vec<Arc<FileSource>>>();
 }

--- a/huff_core/tests/aliased_imports.rs
+++ b/huff_core/tests/aliased_imports.rs
@@ -1,0 +1,33 @@
+use std::{str::FromStr, sync::Arc};
+
+use huff_core::Compiler;
+use huff_utils::prelude::*;
+
+// TODO: fix this test by writing broken inputs to a temp file?
+// #[test]
+// fn test_parses_foundry_aliased_imports() {
+//     println!("In env: {:?}", std::env::current_dir().unwrap());
+//     std::env::set_current_dir("../");
+//     println!("In env: {:?}", std::env::current_dir().unwrap());
+//     let import_bufs =
+//         vec![std::path::PathBuf::from_str("examples/erc20/contracts/ERC20.huff").unwrap()];
+//     let potentials = Compiler::fetch_sources(import_bufs)
+//         .into_iter()
+//         .collect::<Vec<Result<Arc<FileSource>, CompilerError<'_>>>>();
+//     for import in potentials {
+//         import.unwrap();
+//     }
+// }
+
+#[test]
+#[should_panic]
+fn test_invalid_imports_break() {
+    let import_bufs =
+        vec![std::path::PathBuf::from_str("unaliased/erc20/contracts/ERC20.huff").unwrap()];
+    let potentials = Compiler::fetch_sources(import_bufs)
+        .into_iter()
+        .collect::<Vec<Result<Arc<FileSource>, CompilerError<'_>>>>();
+    for import in potentials {
+        import.unwrap();
+    }
+}

--- a/huff_core/tests/erc20.rs
+++ b/huff_core/tests/erc20.rs
@@ -4,7 +4,7 @@ use huff_codegen::Codegen;
 use huff_core::*;
 use huff_lexer::*;
 use huff_parser::*;
-use huff_utils::prelude::*;
+use huff_utils::{files, prelude::*};
 
 #[test]
 fn test_erc20_compile() {
@@ -17,7 +17,8 @@ fn test_erc20_compile() {
 
     // Recurse file deps + generate flattened source
     let file_source = file_sources.get(0).unwrap();
-    let recursed_file_source = Compiler::recurse_deps(Arc::clone(file_source)).unwrap();
+    let recursed_file_source =
+        Compiler::recurse_deps(Arc::clone(file_source), &files::Remapper::new("./")).unwrap();
     let flattened = FileSource::fully_flatten(Arc::clone(&recursed_file_source));
     let full_source = FullFileSource {
         source: &flattened.0,

--- a/huff_core/tests/erc721.rs
+++ b/huff_core/tests/erc721.rs
@@ -4,7 +4,7 @@ use huff_codegen::Codegen;
 use huff_core::*;
 use huff_lexer::*;
 use huff_parser::*;
-use huff_utils::prelude::*;
+use huff_utils::{files, prelude::*};
 
 #[test]
 fn test_erc721_compile() {
@@ -17,7 +17,8 @@ fn test_erc721_compile() {
 
     // Recurse file deps + generate flattened source
     let file_source = file_sources.get(0).unwrap();
-    let recursed_file_source = Compiler::recurse_deps(Arc::clone(file_source)).unwrap();
+    let recursed_file_source =
+        Compiler::recurse_deps(Arc::clone(file_source), &files::Remapper::new("./")).unwrap();
     let flattened = FileSource::fully_flatten(Arc::clone(&recursed_file_source));
     let full_source = FullFileSource {
         source: &flattened.0,

--- a/huff_core/tests/recurse_deps.rs
+++ b/huff_core/tests/recurse_deps.rs
@@ -1,11 +1,11 @@
 use std::{path::PathBuf, sync::Arc};
 
 use huff_core::Compiler;
-use huff_utils::files::FileSource;
+use huff_utils::files;
 
 #[test]
 fn test_recursing_fs_dependencies() {
-    let file_sources: Vec<Arc<FileSource>> = Compiler::fetch_sources(vec![PathBuf::from(
+    let file_sources: Vec<Arc<files::FileSource>> = Compiler::fetch_sources(vec![PathBuf::from(
         "../huff-examples/erc20/contracts/ERC20.huff".to_string(),
     )])
     .iter()
@@ -13,7 +13,7 @@ fn test_recursing_fs_dependencies() {
     .collect();
     assert_eq!(file_sources.len(), 1);
     let erc20_file_source = file_sources[0].clone();
-    let res = Compiler::recurse_deps(Arc::clone(&erc20_file_source));
+    let res = Compiler::recurse_deps(Arc::clone(&erc20_file_source), &files::Remapper::new("./"));
     let full_erc20_file_source = res.unwrap();
     let dependencies = full_erc20_file_source.dependencies.as_ref().unwrap();
     assert_eq!(dependencies.len(), 4);
@@ -25,7 +25,7 @@ fn test_recursing_fs_dependencies() {
 
 #[test]
 fn test_recursing_external_dependencies() {
-    let file_sources: Vec<Arc<FileSource>> = Compiler::fetch_sources(vec![PathBuf::from(
+    let file_sources: Vec<Arc<files::FileSource>> = Compiler::fetch_sources(vec![PathBuf::from(
         "../huff-examples/erc20/contracts/ERC20.huff".to_string(),
     )])
     .iter()
@@ -33,7 +33,7 @@ fn test_recursing_external_dependencies() {
     .collect();
     assert_eq!(file_sources.len(), 1);
     let erc20_file_source = file_sources[0].clone();
-    let res = Compiler::recurse_deps(Arc::clone(&erc20_file_source));
+    let res = Compiler::recurse_deps(Arc::clone(&erc20_file_source), &files::Remapper::new("./"));
     let full_erc20_file_source = res.unwrap();
     let dependencies = full_erc20_file_source.dependencies.as_ref().unwrap();
     assert_eq!(dependencies.len(), 4);

--- a/huff_parser/src/lib.rs
+++ b/huff_parser/src/lib.rs
@@ -152,6 +152,18 @@ impl Parser {
             }
         };
 
+        // Check for foundry toml remappings
+        // TODO: memoize remappings
+        // p = match &self.base {
+        //     Some(b) => FileSource::extract_remappings(b, &p).unwrap_or_default().replacen(
+        //         "contracts/contracts",
+        //         "contracts",
+        //         1,
+        //     ),
+        //     None => p,
+        // };
+        // tracing::info!(target: "parser", "LOCALIZED IMPORT: {}", p);
+
         // Localize import path using out base
         p = match &self.base {
             Some(b) => FileSource::localize_file(b, &p).unwrap_or_default().replacen(

--- a/huff_parser/src/lib.rs
+++ b/huff_parser/src/lib.rs
@@ -7,12 +7,12 @@
 use huff_utils::{
     ast::*,
     error::*,
-    prelude::{bytes32_to_string, hash_bytes, str_to_bytes32, FileSource, Span},
+    files,
+    prelude::{bytes32_to_string, hash_bytes, str_to_bytes32, Span},
     token::{Token, TokenKind},
     types::*,
 };
 use regex::Regex;
-use std::path::Path;
 
 /// The Parser
 #[derive(Debug, Clone)]
@@ -27,13 +27,16 @@ pub struct Parser {
     pub base: Option<String>,
     /// A collection of current spans
     pub spans: Vec<Span>,
+    /// Our remapper
+    pub remapper: files::Remapper,
 }
 
 impl Parser {
     /// Public associated function that instantiates a Parser.
     pub fn new(tokens: Vec<Token>, base: Option<String>) -> Self {
         let initial_token = tokens.get(0).unwrap().clone();
-        Self { tokens, cursor: 0, current_token: initial_token, base, spans: vec![] }
+        let remapper = files::Remapper::new("./");
+        Self { tokens, cursor: 0, current_token: initial_token, base, spans: vec![], remapper }
     }
 
     /// Resets the current token and cursor to the first token in the parser's token vec
@@ -138,7 +141,7 @@ impl Parser {
         // Then let's grab and validate the file path
         self.match_kind(TokenKind::Str("x".to_string()))?;
         let tok = self.peek_behind().unwrap().kind;
-        let mut p = match tok {
+        let p = match tok {
             TokenKind::Str(file_path) => file_path,
             _ => {
                 tracing::error!(target: "parser", "INVALID IMPORT PATH: {}", tok);
@@ -152,44 +155,7 @@ impl Parser {
             }
         };
 
-        // Check for foundry toml remappings
-        // TODO: memoize remappings
-        // p = match &self.base {
-        //     Some(b) => FileSource::extract_remappings(b, &p).unwrap_or_default().replacen(
-        //         "contracts/contracts",
-        //         "contracts",
-        //         1,
-        //     ),
-        //     None => p,
-        // };
-        // tracing::info!(target: "parser", "LOCALIZED IMPORT: {}", p);
-
-        // Localize import path using out base
-        p = match &self.base {
-            Some(b) => FileSource::localize_file(b, &p).unwrap_or_default().replacen(
-                "contracts/contracts",
-                "contracts",
-                1,
-            ),
-            None => p,
-        };
-        tracing::info!(target: "parser", "LOCALIZED IMPORT: {}", p);
-
-        let path = Path::new(&p);
-
-        // Validate that a file @ the path exists
-        if !(path.exists() && path.is_file() && path.to_str().unwrap().ends_with(".huff")) {
-            tracing::error!(target: "parser", "INVALID IMPORT PATH: {:?}", path.to_str());
-            let new_spans = self.spans.clone();
-            self.spans = vec![];
-            return Err(ParserError {
-                kind: ParserErrorKind::InvalidImportPath(p),
-                hint: None,
-                spans: AstSpan(new_spans),
-            })
-        }
-
-        Ok(path.to_path_buf())
+        Ok(std::path::PathBuf::from(p))
     }
 
     /// Match current token to a type.

--- a/huff_parser/tests/imports.rs
+++ b/huff_parser/tests/imports.rs
@@ -50,3 +50,17 @@ fn fails_to_parse_invalid_import() {
     let import_path = contract.imports[0].clone();
     assert_eq!(import_path.to_str().unwrap(), "../huff-examples/erc20/contracts/ERC1155.huff");
 }
+
+// #[test]
+// fn parses_foundry_import_style() {
+//     let source = " /* .,*./. */  #include \"examples/erc20/contracts/ERC20.huff\"";
+//     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+//     let lexer = Lexer::new(flattened_source);
+//     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+//     let mut parser = Parser::new(tokens, None);
+//     let contract = parser.parse().unwrap();
+//     assert_eq!(parser.current_token.kind, TokenKind::Eof);
+
+//     let import_path = contract.imports[0].clone();
+//     assert_eq!(import_path.to_str().unwrap(), "../huff-examples/erc20/contracts/ERC20.huff");
+// }

--- a/huff_parser/tests/imports.rs
+++ b/huff_parser/tests/imports.rs
@@ -34,33 +34,3 @@ fn parses_deep_imports() {
     let import_path = contract.imports[0].clone();
     assert_eq!(import_path.to_str().unwrap(), "../huff-examples/erc20/contracts/ERC20.huff");
 }
-
-#[test]
-#[should_panic]
-fn fails_to_parse_invalid_import() {
-    let source = " /* .,*./. */  #include \"../huff-examples/erc20/contracts/ERC1155.huff\"";
-
-    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-    let lexer = Lexer::new(flattened_source);
-    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
-    let mut parser = Parser::new(tokens, None);
-    let contract = parser.parse().unwrap();
-    assert_eq!(parser.current_token.kind, TokenKind::Eof);
-
-    let import_path = contract.imports[0].clone();
-    assert_eq!(import_path.to_str().unwrap(), "../huff-examples/erc20/contracts/ERC1155.huff");
-}
-
-// #[test]
-// fn parses_foundry_import_style() {
-//     let source = " /* .,*./. */  #include \"examples/erc20/contracts/ERC20.huff\"";
-//     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
-//     let lexer = Lexer::new(flattened_source);
-//     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
-//     let mut parser = Parser::new(tokens, None);
-//     let contract = parser.parse().unwrap();
-//     assert_eq!(parser.current_token.kind, TokenKind::Eof);
-
-//     let import_path = contract.imports[0].clone();
-//     assert_eq!(import_path.to_str().unwrap(), "../huff-examples/erc20/contracts/ERC20.huff");
-// }

--- a/huff_utils/Cargo.toml
+++ b/huff_utils/Cargo.toml
@@ -26,3 +26,5 @@ pathdiff = "0.2.1"
 ethers-core = "0.13.0"
 itertools = "0.10.3"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
+toml = "0.5.9"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }


### PR DESCRIPTION
## Overview

Tackles #187 

Adds remapping support for import resolutions. So a remapping in a foundry.toml can be supported when compiling huff contracts. For example, a remapping for huffmate like `huffmate/=lib/huffmate/src/` located in a `foundry.toml` file can be successfully parsed by the huff compiler. This allows you to import huffmate contracts inside a huff contract using `foundry.toml` remappings (WLOG)

Note: This PR rips out file path validation logic in the parser since files are validated and fully flattened at the compiler top-level.
