### PR TITLE
add checks for evm types as arg names

### DIFF
--- a/huff_parser/tests/function.rs
+++ b/huff_parser/tests/function.rs
@@ -211,3 +211,15 @@ fn cannot_parse_invalid_function_definition() {
     let mut parser = Parser::new(tokens, None);
     parser.parse().unwrap();
 }
+
+#[test]
+#[should_panic]
+fn test_functions_with_keyword_arg_names_errors() {
+    // The function parameter's name is a reserved keyword; this should throw an error
+    let source: &str = "#define function myFunc(uint256 uint256) pure returns(uint256)";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    parser.parse().unwrap();
+}

--- a/huff_utils/src/error.rs
+++ b/huff_utils/src/error.rs
@@ -23,6 +23,8 @@ pub struct ParserError {
 pub enum ParserErrorKind {
     /// Unexpected type
     UnexpectedType(TokenKind),
+    /// Argument name is a reserved evm primitive type keyword
+    InvalidTypeAsArgumentName(TokenKind),
     /// Invalid definition
     InvalidDefinition(TokenKind),
     /// Invalid constant value
@@ -311,6 +313,14 @@ impl<'a> fmt::Display for CompilerError<'a> {
                     write!(
                         f,
                         "\nError: Unexpected Type: \"{}\" \n{}\n",
+                        ut,
+                        pe.spans.error(pe.hint.as_ref())
+                    )
+                }
+                ParserErrorKind::InvalidTypeAsArgumentName(ut) => {
+                    write!(
+                        f,
+                        "\nError: Unexpected Argument Name is an EVM Type: \"{}\" \n{}\n",
                         ut,
                         pe.spans.error(pe.hint.as_ref())
                     )


### PR DESCRIPTION
## Overview

Attempts a fix for #196 

#### Checklist

- [x] 1.1 Naming parameters as native solidity datatypes should lead to an error
`#define function balanceOf(address uint256) view returns (uint256 balance)` => errors with:
![carbon(2)](https://user-images.githubusercontent.com/21288394/186727668-adde4e9f-c589-4ba2-bd62-e741d612debb.png)

- [ ] 1.2 A lack of a comma in a function definition should not lead to following datatypes affecting the function signature
- [ ] 2. You should be allowed to give a parameter a name that starts with "int" / "uint" / "bytes"
- [ ] 3. You should be able to name dynamic parameters (`string`, `bytes`, `<type>[]`, etc.)