### PR TITLE
various fixes and features

### DIFF
--- a/huff_codegen/src/irgen/statements.rs
+++ b/huff_codegen/src/irgen/statements.rs
@@ -101,6 +101,7 @@ pub fn statement_gen(
                     scope,
                     *offset,
                     mis,
+                    false,
                 ) {
                     Ok(r) => r,
                     Err(e) => {
@@ -185,6 +186,7 @@ pub fn statement_gen(
                         scope,
                         *offset,
                         mis,
+                        ir_macro.name.eq("CONSTRUCTOR"),
                     ) {
                         Ok(r) => r,
                         Err(e) => {

--- a/huff_codegen/src/lib.rs
+++ b/huff_codegen/src/lib.rs
@@ -280,6 +280,26 @@ impl Codegen {
                     bytes.push((starting_offset, Bytes(push_bytes)));
                 }
                 IRByteType::Statement(s) => {
+                    // if we have a codesize call for the constructor here, from within the
+                    // constructor, we skip
+                    if let Some(m) = scope.get(0) {
+                        if m.name == "CONSTRUCTOR" {
+                            if let StatementType::BuiltinFunctionCall(BuiltinFunctionCall {
+                                kind,
+                                args,
+                                span: _,
+                            }) = &s.ty
+                            {
+                                if kind.eq(&BuiltinFunctionKind::Codesize) {
+                                    if let Some(arg) = args.get(0) {
+                                        if Some("CONSTRUCTOR".to_string()) == arg.name {
+                                            continue
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                     let mut push_bytes = statement_gen(
                         &s,
                         contract,

--- a/huff_core/tests/push_overrides.rs
+++ b/huff_core/tests/push_overrides.rs
@@ -1,0 +1,88 @@
+use huff_codegen::*;
+use huff_lexer::*;
+use huff_parser::*;
+use huff_utils::prelude::*;
+
+#[test]
+fn test_gracefully_pads_push_override() {
+    // Create the raw source
+    const OVERRIDEN_PUSH: &str = r#"
+        #define macro CONSTRUCTOR() = {
+            push32 0x234
+        }
+        #define macro MAIN() = {}
+    "#;
+
+    // Lex and Parse the source code
+    let flattened_source = FullFileSource { source: OVERRIDEN_PUSH, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    // Grab the first macro
+    let mut contract = parser.parse().unwrap();
+    // Derive storage pointers
+    contract.derive_storage_pointers();
+
+    // Instantiate Codegen
+    let cg = Codegen::new();
+
+    // The codegen instance should have no artifact
+    assert!(cg.artifact.is_none());
+
+    // Have the Codegen create the constructor bytecode
+    let cbytes = Codegen::generate_constructor_bytecode(&contract).unwrap();
+    assert_eq!(
+        cbytes,
+        String::from("7f0000000000000000000000000000000000000000000000000000000000000234")
+    );
+}
+
+#[test]
+fn test_constructs_exact_push_override() {
+    // Create the raw source
+    const OVERRIDEN_PUSH: &str = r#"
+        #define macro CONSTRUCTOR() = {
+            push1 0x34
+        }
+        #define macro MAIN() = {}
+    "#;
+
+    // Lex and Parse the source code
+    let flattened_source = FullFileSource { source: OVERRIDEN_PUSH, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    // Grab the first macro
+    let mut contract = parser.parse().unwrap();
+    // Derive storage pointers
+    contract.derive_storage_pointers();
+
+    // Instantiate Codegen
+    let cg = Codegen::new();
+
+    // The codegen instance should have no artifact
+    assert!(cg.artifact.is_none());
+
+    // Have the Codegen create the constructor bytecode
+    let cbytes = Codegen::generate_constructor_bytecode(&contract).unwrap();
+    assert_eq!(cbytes, String::from("6034"));
+}
+
+#[test]
+#[should_panic]
+fn test_fails_on_push_underflow() {
+    const OVERRIDEN_PUSH: &str = r#"
+        #define macro CONSTRUCTOR() = {
+            push1 0x0234
+        }
+        #define macro MAIN() = {}
+    "#;
+
+    let flattened_source = FullFileSource { source: OVERRIDEN_PUSH, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+    parser.parse().unwrap();
+}

--- a/huff_parser/src/lib.rs
+++ b/huff_parser/src/lib.rs
@@ -567,6 +567,9 @@ impl Parser {
                                 let curr_spans = vec![self.current_token.span.clone()];
                                 tracing::info!(target: "parser", "PARSING MACRO BODY: [LITERAL: {}]", hex::encode(val));
                                 self.consume();
+
+                                // TODO: Here we need to gracefully add zeros to the beginning of
+                                // the literal
                                 statements.push(Statement {
                                     ty: StatementType::Literal(val),
                                     span: AstSpan(curr_spans),

--- a/huff_parser/src/lib.rs
+++ b/huff_parser/src/lib.rs
@@ -560,6 +560,30 @@ impl Parser {
                         ty: StatementType::Opcode(o),
                         span: AstSpan(curr_spans),
                     });
+                    // If the opcode is a push, we need to parse the next literal
+                    if o.is_push() {
+                        match self.current_token.kind.clone() {
+                            TokenKind::Literal(val) => {
+                                let curr_spans = vec![self.current_token.span.clone()];
+                                tracing::info!(target: "parser", "PARSING MACRO BODY: [LITERAL: {}]", hex::encode(val));
+                                self.consume();
+                                statements.push(Statement {
+                                    ty: StatementType::Literal(val),
+                                    span: AstSpan(curr_spans),
+                                });
+                            }
+                            _ => {
+                                return Err(ParserError {
+                                    kind: ParserErrorKind::InvalidPush(o),
+                                    hint: Some(format!(
+                                        "Expected literal following \"{:?}\", found \"{:?}\"",
+                                        o, self.current_token.kind
+                                    )),
+                                    spans: AstSpan(vec![self.current_token.span.clone()]),
+                                })
+                            }
+                        }
+                    }
                 }
                 TokenKind::Ident(ident_str) => {
                     let mut curr_spans = vec![self.current_token.span.clone()];

--- a/huff_parser/tests/opcodes.rs
+++ b/huff_parser/tests/opcodes.rs
@@ -56,3 +56,93 @@ fn test_invalid_push_non_literal() {
     // Should fail here
     parser.parse().unwrap();
 }
+
+#[test]
+fn test_push_literals() {
+    let source: &str = r#"
+        #define macro MAIN() = {
+            push1 0x10
+            push32 0x108
+            push1 0x10 0x10
+        }
+    "#;
+
+    // Parse tokens
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+
+    let expected_tokens = vec![
+        Token { kind: TokenKind::Whitespace, span: Span { start: 0, end: 9, file: None } },
+        Token { kind: TokenKind::Define, span: Span { start: 9, end: 16, file: None } },
+        Token { kind: TokenKind::Whitespace, span: Span { start: 16, end: 17, file: None } },
+        Token { kind: TokenKind::Macro, span: Span { start: 17, end: 22, file: None } },
+        Token { kind: TokenKind::Whitespace, span: Span { start: 22, end: 23, file: None } },
+        Token {
+            kind: TokenKind::Ident("MAIN".to_string()),
+            span: Span { start: 23, end: 27, file: None },
+        },
+        Token { kind: TokenKind::OpenParen, span: Span { start: 27, end: 28, file: None } },
+        Token { kind: TokenKind::CloseParen, span: Span { start: 28, end: 29, file: None } },
+        Token { kind: TokenKind::Whitespace, span: Span { start: 29, end: 30, file: None } },
+        Token { kind: TokenKind::Assign, span: Span { start: 30, end: 31, file: None } },
+        Token { kind: TokenKind::Whitespace, span: Span { start: 31, end: 32, file: None } },
+        Token { kind: TokenKind::OpenBrace, span: Span { start: 32, end: 33, file: None } },
+        Token { kind: TokenKind::Whitespace, span: Span { start: 33, end: 46, file: None } },
+        Token {
+            kind: TokenKind::Opcode(Opcode::Push1),
+            span: Span { start: 46, end: 51, file: None },
+        },
+        Token { kind: TokenKind::Whitespace, span: Span { start: 51, end: 52, file: None } },
+        Token {
+            kind: TokenKind::Literal([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 16,
+            ]),
+            span: Span { start: 54, end: 56, file: None },
+        },
+        Token { kind: TokenKind::Whitespace, span: Span { start: 56, end: 69, file: None } },
+        Token {
+            kind: TokenKind::Opcode(Opcode::Push32),
+            span: Span { start: 69, end: 75, file: None },
+        },
+        Token { kind: TokenKind::Whitespace, span: Span { start: 75, end: 76, file: None } },
+        Token {
+            kind: TokenKind::Literal([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 1, 8,
+            ]),
+            span: Span { start: 78, end: 81, file: None },
+        },
+        Token { kind: TokenKind::Whitespace, span: Span { start: 81, end: 94, file: None } },
+        Token {
+            kind: TokenKind::Opcode(Opcode::Push1),
+            span: Span { start: 94, end: 99, file: None },
+        },
+        Token { kind: TokenKind::Whitespace, span: Span { start: 99, end: 100, file: None } },
+        Token {
+            kind: TokenKind::Literal([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 16,
+            ]),
+            span: Span { start: 102, end: 104, file: None },
+        },
+        Token { kind: TokenKind::Whitespace, span: Span { start: 104, end: 105, file: None } },
+        Token {
+            kind: TokenKind::Literal([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 16,
+            ]),
+            span: Span { start: 107, end: 109, file: None },
+        },
+        Token { kind: TokenKind::Whitespace, span: Span { start: 109, end: 118, file: None } },
+        Token { kind: TokenKind::CloseBrace, span: Span { start: 118, end: 119, file: None } },
+        Token { kind: TokenKind::Whitespace, span: Span { start: 119, end: 124, file: None } },
+        Token { kind: TokenKind::Eof, span: Span { start: 124, end: 124, file: None } },
+    ];
+    assert_eq!(expected_tokens, tokens);
+
+    // This should parse correctly
+    let mut parser = Parser::new(tokens, None);
+    parser.parse().unwrap();
+}

--- a/huff_parser/tests/opcodes.rs
+++ b/huff_parser/tests/opcodes.rs
@@ -34,3 +34,25 @@ fn not_mistaken_as_opcode() {
         assert_eq!(actual_label, TokenKind::Label(label));
     }
 }
+
+#[test]
+#[should_panic]
+fn test_invalid_push_non_literal() {
+    let source: &str = r#"
+        // Here we have a macro invocation directly in the parameter list - this should fail
+        #define macro MAIN() = takes (0) returns (0) {
+            push1 0x10
+            push32 0x108
+            push1 push1
+        }
+    "#;
+
+    // Parse tokens
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    // Should fail here
+    parser.parse().unwrap();
+}

--- a/huff_tests/src/runner.rs
+++ b/huff_tests/src/runner.rs
@@ -168,6 +168,7 @@ impl TestRunner {
             &mut vec![m.to_owned()],
             0,
             &mut Vec::default(),
+            false,
         ) {
             // Generate table bytecode for compiled test macro
             Ok(res) => match Codegen::gen_table_bytecode(res) {

--- a/huff_utils/src/ast.rs
+++ b/huff_utils/src/ast.rs
@@ -570,7 +570,7 @@ impl MacroDefinition {
                                     ty: IRByteType::Bytes(Bytes(hex_literal)),
                                     span: statement.span.clone(),
                                 });
-                                statement_iter.next();
+                                // statement_iter.next();
                             }
                             _ => {
                                 // We have a push without a literal - this should be caught by the

--- a/huff_utils/src/ast.rs
+++ b/huff_utils/src/ast.rs
@@ -566,11 +566,11 @@ impl MacroDefinition {
                         match statement_iter.next() {
                             Some(Statement { ty: StatementType::Literal(l), span: _ }) => {
                                 let hex_literal: String = bytes32_to_string(l, false);
+                                let prefixed_hex_literal = o.prefix_push_literal(&hex_literal);
                                 inner_irbytes.push(IRBytes {
-                                    ty: IRByteType::Bytes(Bytes(hex_literal)),
+                                    ty: IRByteType::Bytes(Bytes(prefixed_hex_literal)),
                                     span: statement.span.clone(),
                                 });
-                                // statement_iter.next();
                             }
                             _ => {
                                 // We have a push without a literal - this should be caught by the

--- a/huff_utils/src/bytes_util.rs
+++ b/huff_utils/src/bytes_util.rs
@@ -25,11 +25,8 @@ pub fn str_to_bytes32(s: &str) -> [u8; 32] {
 pub fn bytes32_to_string(bytes: &[u8; 32], prefixed: bool) -> String {
     let mut s = String::default();
     let start = bytes.iter().position(|b| *b != 0).unwrap_or(bytes.len() - 1);
-    tracing::debug!(target: "bytes_util", "got start: {}", start);
     for b in &bytes[start..bytes.len()] {
-        tracing::debug!(target: "bytes_util", "Converting byte: {}", b);
         s = format!("{}{:02x}", s, *b);
-        tracing::debug!(target: "bytes_util", "Converted byte: {} to string {}", b, s);
     }
     format!("{}{}", if prefixed { "0x" } else { "" }, s)
 }

--- a/huff_utils/src/error.rs
+++ b/huff_utils/src/error.rs
@@ -1,7 +1,7 @@
 use crate::{
     files::{Span, Spanned},
     io::UnpackError,
-    prelude::{parse_extension, AstSpan},
+    prelude::{parse_extension, AstSpan, Opcode},
     report::{Report, Reporter},
     token::TokenKind,
 };
@@ -21,6 +21,8 @@ pub struct ParserError {
 /// A Type of Parser Error
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum ParserErrorKind {
+    /// An invalid literal was passed to a push opcode
+    InvalidPush(Opcode),
     /// Unexpected type
     UnexpectedType(TokenKind),
     /// Argument name is a reserved evm primitive type keyword
@@ -314,6 +316,14 @@ impl<'a> fmt::Display for CompilerError<'a> {
                 }
             },
             CompilerError::ParserError(pe) => match &pe.kind {
+                ParserErrorKind::InvalidPush(op) => {
+                    write!(
+                        f,
+                        "\nError: Invalid use of \"{:?}\" \n{}\n",
+                        op,
+                        pe.spans.error(pe.hint.as_ref())
+                    )
+                }
                 ParserErrorKind::UnexpectedType(ut) => {
                     write!(
                         f,

--- a/huff_utils/src/evm.rs
+++ b/huff_utils/src/evm.rs
@@ -6,7 +6,7 @@ use strum_macros::EnumString;
 /// They are arranged in a particular order such that all the opcodes that have common
 /// prefixes are ordered by decreasing length to avoid mismatch when lexing.
 /// Example : [origin, or] or [push32, ..., push3]
-pub const OPCODES: [&str; 144] = [
+pub const OPCODES: [&str; 146] = [
     "lt",
     "gt",
     "slt",
@@ -77,6 +77,8 @@ pub const OPCODES: [&str; 144] = [
     "log2",
     "log3",
     "log4",
+    "tload",
+    "tstore",
     "create2",
     "create",
     "callcode",
@@ -289,6 +291,8 @@ pub static OPCODES_MAP: phf::Map<&'static str, Opcode> = phf_map! {
     "log2" => Opcode::Log2,
     "log3" => Opcode::Log3,
     "log4" => Opcode::Log4,
+    "tload" => Opcode::TLoad,
+    "tstore" => Opcode::TStore,
     "create" => Opcode::Create,
     "call" => Opcode::Call,
     "callcode" => Opcode::Callcode,
@@ -572,6 +576,10 @@ pub enum Opcode {
     Log3,
     /// Append Log Record with 4 Topics
     Log4,
+    /// Transaction-persistent, but storage-ephemeral variable load
+    TLoad,
+    /// Transaction-persistent, but storage-ephemeral variable store
+    TStore,
     /// Create a new account with associated code
     Create,
     /// Message-call into an account
@@ -735,6 +743,8 @@ impl Opcode {
             Opcode::Log2 => "a2",
             Opcode::Log3 => "a3",
             Opcode::Log4 => "a4",
+            Opcode::TLoad => "b3",
+            Opcode::TStore => "b4",
             Opcode::Create => "f0",
             Opcode::Call => "f1",
             Opcode::Callcode => "f2",
@@ -747,6 +757,45 @@ impl Opcode {
             Opcode::Selfdestruct => "ff",
         };
         opcode_str.to_string()
+    }
+
+    /// Returns if the current opcode is a push opcode
+    pub fn is_push(&self) -> bool {
+        matches!(
+            self,
+            Opcode::Push1 |
+                Opcode::Push2 |
+                Opcode::Push3 |
+                Opcode::Push4 |
+                Opcode::Push5 |
+                Opcode::Push6 |
+                Opcode::Push7 |
+                Opcode::Push8 |
+                Opcode::Push9 |
+                Opcode::Push10 |
+                Opcode::Push11 |
+                Opcode::Push12 |
+                Opcode::Push13 |
+                Opcode::Push14 |
+                Opcode::Push15 |
+                Opcode::Push16 |
+                Opcode::Push17 |
+                Opcode::Push18 |
+                Opcode::Push19 |
+                Opcode::Push20 |
+                Opcode::Push21 |
+                Opcode::Push22 |
+                Opcode::Push23 |
+                Opcode::Push24 |
+                Opcode::Push25 |
+                Opcode::Push26 |
+                Opcode::Push27 |
+                Opcode::Push28 |
+                Opcode::Push29 |
+                Opcode::Push30 |
+                Opcode::Push31 |
+                Opcode::Push32
+        )
     }
 }
 

--- a/huff_utils/src/evm.rs
+++ b/huff_utils/src/evm.rs
@@ -797,6 +797,22 @@ impl Opcode {
                 Opcode::Push32
         )
     }
+
+    /// Prefixes the literal if necessary
+    pub fn prefix_push_literal(&self, literal: &str) -> String {
+        if self.is_push() {
+            if let Ok(len) = u8::from_str_radix(&self.to_string(), 16) {
+                if len >= 96 {
+                    let zeros_needed = ((len - 96 + 1) * 2) - literal.len() as u8;
+                    let zero_prefix =
+                        (0..zeros_needed).map(|_| "0").collect::<Vec<&str>>().join("");
+                    return format!("{}{}", zero_prefix, literal)
+                }
+            }
+        }
+
+        literal.to_string()
+    }
 }
 
 impl fmt::Display for Opcode {

--- a/huff_utils/src/evm.rs
+++ b/huff_utils/src/evm.rs
@@ -803,15 +803,33 @@ impl Opcode {
         if self.is_push() {
             if let Ok(len) = u8::from_str_radix(&self.to_string(), 16) {
                 if len >= 96 {
-                    let zeros_needed = ((len - 96 + 1) * 2) - literal.len() as u8;
-                    let zero_prefix =
-                        (0..zeros_needed).map(|_| "0").collect::<Vec<&str>>().join("");
-                    return format!("{}{}", zero_prefix, literal)
+                    let size = (len - 96 + 1) * 2;
+                    // This case should be caught in the parser
+                    if literal.len() <= size as usize {
+                        let zeros_needed = size - literal.len() as u8;
+                        let zero_prefix =
+                            (0..zeros_needed).map(|_| "0").collect::<Vec<&str>>().join("");
+                        return format!("{}{}", zero_prefix, literal)
+                    }
                 }
             }
         }
 
         literal.to_string()
+    }
+
+    /// Checks if the value overflows the given push opcode
+    pub fn push_overflows(&self, literal: &str) -> bool {
+        if self.is_push() {
+            if let Ok(len) = u8::from_str_radix(&self.to_string(), 16) {
+                if len >= 96 {
+                    let size = (len - 96 + 1) * 2;
+                    return literal.len() > size as usize
+                }
+            }
+        }
+
+        false
     }
 }
 


### PR DESCRIPTION
## Overview

- [x] `tload` and `tstore` opcodes
- [x] `pushX` opcode overrides
- [x] Fixes use of `__Codesize(CONSTRUCTOR)` from inside the constructor #206