### PR TITLE
fix(huff_utils) incorrect path localization

### DIFF
--- a/huff_utils/src/files.rs
+++ b/huff_utils/src/files.rs
@@ -232,7 +232,14 @@ impl FileSource {
 
     /// Localizes a file path, if path is relative
     pub fn localize_file(parent: &str, child: &str) -> Option<String> {
-        let mut prefix = match FileSource::derive_dir(parent) {
+        let mut prefixed_parent;
+        if !parent.starts_with('.') {
+            prefixed_parent = "./".to_owned();
+            prefixed_parent.push_str(parent);
+        } else {
+            prefixed_parent = parent.to_owned();
+        }
+        let mut prefix = match FileSource::derive_dir(prefixed_parent.as_str()) {
             Some(p) => {
                 if p.is_empty() {
                     String::from(".")

--- a/huff_utils/tests/files.rs
+++ b/huff_utils/tests/files.rs
@@ -110,4 +110,8 @@ fn test_localize_file() {
         files::FileSource::localize_file("../../examples/ERC20.huff", "../../../Address.huff")
             .unwrap();
     assert_eq!(localized, "../../../../Address.huff");
+    let localized =
+        files::FileSource::localize_file("examples/ERC20.huff", "../random_dir/Address.huff")
+            .unwrap();
+    assert_eq!(localized, "./random_dir/Address.huff");
 }


### PR DESCRIPTION
## Overview

When the parent path doesn't start with a `./` or `../` and the child starts with a `../` the calculated path is incorrect.

e.g.

```rust
files::FileSource::localize_file("examples/ERC20.huff", "../random_dir/Address.huff")

// returns    "../examples/random_dir/Address.huff"
// expected   "./random_dir/Address.huff"
```

Fixed by checking if parent starts with a `.` and if not prefixing it with one.

Added a regression test.
