### PR TITLE
chore: lock ubuntu 20.04 in release.yml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,9 +3,9 @@ name: Release version
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 env:
@@ -77,12 +77,12 @@ jobs:
           # The target is used by Cargo
           # The arch is either 386, arm64 or amd64
           # The svm target platform to use for the binary https://github.com/roynalnaruto/svm-rs/blob/84cbe0ac705becabdc13168bae28a45ad2299749/svm-builds/build.rs#L4-L24
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             platform: linux
             target: x86_64-unknown-linux-gnu
             arch: amd64
             svm_target_platform: linux-amd64
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             platform: linux
             target: aarch64-unknown-linux-gnu
             arch: arm64
@@ -197,8 +197,8 @@ jobs:
         if: ${{ env.IS_NIGHTLY }}
         uses: softprops/action-gh-release@v1
         with:
-          name: 'Nightly'
-          tag_name: 'nightly'
+          name: "Nightly"
+          tag_name: "nightly"
           prerelease: true
           body: ${{ needs.prepare.outputs.changelog }}
           files: |


### PR DESCRIPTION
## Overview

When running `huffup` on ubutnu 20.04 (focal) it results in a  `GLIBC_2.34' not found` error. This error is quite hard to appease as upgrading glibc is quite a task that various forums do not recommend. However after installing a ubuntu 22.~ release and running huffup the issue disappears.  

I think the error is occuring as the build system currently runs on `ububtu-latest` which is no longer 20.04 but 22. Such it is compiling with a version of glibc that is not available to ubuntu 20.04 without a risky upgrade path.

This pr locks the build system to use 20.04 which should unblock users who are encountering this issue.

<!--
Thank you for creating a Pull Request!
Please provide a short description here and review the requirements below.
Bug fixes and new features should include tests.

Make sure to run these checks before opening a pr!
```sh
cargo check --all
cargo test --all --all-features
cargo +nightly fmt -- --check
cargo +nightly clippy --all --all-features -- -D warnings
```

Recommended method to auto format your code before pushing:
```sh
cargo +nightly fmt --all
```
-->
