### PR TITLE
feat: __VERBATIM

### DIFF
--- a/huff_core/tests/verbatim.rs
+++ b/huff_core/tests/verbatim.rs
@@ -1,0 +1,45 @@
+use huff_codegen::*;
+use huff_lexer::*;
+use huff_parser::*;
+use huff_utils::prelude::*;
+
+#[test]
+fn test_verbatim() {
+    let source = r#"
+    #define macro MAIN() = takes(0) returns(0) {
+        __VERBATIM(0x1234567890abcdef)
+    }
+    "#;
+
+    let full_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(full_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, Some("".to_string()));
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // Get main bytecode with verbatim
+    match Codegen::generate_main_bytecode(&contract, None) {
+        Ok(mb) => assert_eq!(mb, "1234567890abcdef".to_string()),
+        Err(_) => panic!("moose"),
+    }
+}
+
+#[test]
+fn test_verbatim_invalid_hex() {
+    let source = r#"
+    #define macro MAIN() = takes(0) returns(0) {
+        __VERBATIM("ggggggg")
+    }
+    "#;
+
+    let full_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(full_source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, Some("".to_string()));
+    let mut contract = parser.parse().unwrap();
+    contract.derive_storage_pointers();
+
+    // Expect failure to generate bytecode with verbatim
+    assert!(Codegen::generate_main_bytecode(&contract, None).is_err());
+}

--- a/huff_utils/src/ast.rs
+++ b/huff_utils/src/ast.rs
@@ -786,6 +786,8 @@ pub enum BuiltinFunctionKind {
     RightPad,
     /// Dynamic constructor arg function
     DynConstructorArg,
+    /// Inject Raw Bytes
+    Verbatim,
 }
 
 impl From<String> for BuiltinFunctionKind {
@@ -799,6 +801,7 @@ impl From<String> for BuiltinFunctionKind {
             "__ERROR" => BuiltinFunctionKind::Error,
             "__RIGHTPAD" => BuiltinFunctionKind::RightPad,
             "__CODECOPY_DYN_ARG" => BuiltinFunctionKind::DynConstructorArg,
+            "__VERBATIM" => BuiltinFunctionKind::Verbatim,
             _ => panic!("Invalid Builtin Function Kind"), /* This should never be reached,
                                                            * builtins are validated with a
                                                            * `try_from` call in the lexer. */
@@ -819,6 +822,7 @@ impl TryFrom<&String> for BuiltinFunctionKind {
             "__ERROR" => Ok(BuiltinFunctionKind::Error),
             "__RIGHTPAD" => Ok(BuiltinFunctionKind::RightPad),
             "__CODECOPY_DYN_ARG" => Ok(BuiltinFunctionKind::DynConstructorArg),
+            "__VERBATIM" => Ok(BuiltinFunctionKind::Verbatim),
             _ => Err(()),
         }
     }

--- a/huff_utils/src/error.rs
+++ b/huff_utils/src/error.rs
@@ -169,6 +169,8 @@ pub enum CodegenErrorKind {
     UsizeConversion(String),
     /// Invalid Arguments
     InvalidArguments(String),
+    /// Invalid Hex String
+    InvalidHex(String),
     /// Invalid Table Statement
     InvalidTableStatement(String),
     /// Invalid Code Length
@@ -225,6 +227,9 @@ impl<W: Write> Report<W> for CodegenError {
             }
             CodegenErrorKind::InvalidArguments(msg) => {
                 write!(f.out, "Invalid arguments: \"{msg}\"")
+            }
+            CodegenErrorKind::InvalidHex(msg) => {
+                write!(f.out, "Invalid hex string: \"{msg}\"")
             }
             CodegenErrorKind::InvalidTableStatement(msg) => {
                 write!(f.out, "Invalid table statement: \"{msg}\"")
@@ -564,6 +569,9 @@ impl<'a> fmt::Display for CompilerError<'a> {
                 }
                 CodegenErrorKind::InvalidArguments(_) => {
                     write!(f, "\nError: Invalid Arguments\n{}\n", ce.span.error(None))
+                }
+                CodegenErrorKind::InvalidHex(_) => {
+                    write!(f, "\nError: Invalid Hex\n{}\n", ce.span.error(None))
                 }
                 CodegenErrorKind::InvalidTableStatement(_) => {
                     write!(f, "\nError: Invalid Table Statement\n{}\n", ce.span.error(None))


### PR DESCRIPTION
## Overview
Implements a `__VERBATIM` builtin that allows developers to inline whatever hex they would like. This is opens the door to test out opcodes that may not already be supported by huff or do some mad stuff like placing code tables in the middle of runtime (idk go wild).

### Contention
Despite there being multiple users who have requested this feature (including issue #225); half of me feels like it may be more harm than good as it opens up ways for people to shoot themselves in the foot. Especially since the way the language has been implemented makes adding opcodes trivial ( it can take as little as 5 minutes ). 
On the other hand, I do feel like it is inline with the Huff ethos to allow the developer to to whatever they would like with their contracts.

That being said, I think it is worth having a discussion around this / shelving if people do not feel like it is useful.

## Usage
```huff
#define macro MAIN() = {
    __VERBATIM(0x5b)
}
```
will yield `5b` as the runtime bytecode

<!--
Thank you for creating a Pull Request!
Please provide a short description here and review the requirements below.
Bug fixes and new features should include tests.

Make sure to run these checks before opening a pr!
```sh
cargo check --all
cargo test --all --all-features
cargo +nightly fmt -- --check
cargo +nightly clippy --all --all-features -- -D warnings
```

Recommended method to auto format your code before pushing:
```sh
cargo +nightly fmt --all
```
-->
