### PR TITLE
fix: broken link to clap's derive feature in cli README

### DIFF
--- a/huff_cli/README.md
+++ b/huff_cli/README.md
@@ -1,7 +1,6 @@
 # Huff CLI
 
-The `huffc` CLI is written using [clap's](https://docs.rs/clap) [derive feature](https://github.com/clap-rs/clap/blob/master/examples/derive_ref/README.md).
-
+The `huffc` CLI is written using [clap's](https://docs.rs/clap) [derive feature](https://docs.rs/clap/latest/clap/_derive/index.html).
 
 ## huffc
 


### PR DESCRIPTION
## Overview

The link to clap's derive feature in the huff_cli readme was broken so I updated it to reference the docs. But if there is a better place to link to I can use that instead!
<!--
Thank you for creating a Pull Request!
Please provide a short description here and review the requirements below.
Bug fixes and new features should include tests.

Make sure to run these checks before opening a pr!
```sh
cargo check --all
cargo test --all --all-features
cargo +nightly fmt -- --check
cargo +nightly clippy --all --all-features -- -D warnings
```

Recommended method to auto format your code before pushing:
```sh
cargo +nightly fmt --all
```
-->
