### PR TITLE
chore(clippy): resolve ambiguous exports

### DIFF
--- a/huff_lexer/tests/arg_calls.rs
+++ b/huff_lexer/tests/arg_calls.rs
@@ -1,6 +1,6 @@
 use huff_lexer::*;
 use huff_utils::{evm::Opcode, prelude::*};
-use std::ops::Deref;
+
 
 #[test]
 fn lexes_arg_calls() {

--- a/huff_lexer/tests/arg_calls.rs
+++ b/huff_lexer/tests/arg_calls.rs
@@ -1,7 +1,6 @@
 use huff_lexer::*;
 use huff_utils::{evm::Opcode, prelude::*};
 
-
 #[test]
 fn lexes_arg_calls() {
     let source = r#"

--- a/huff_lexer/tests/builtins.rs
+++ b/huff_lexer/tests/builtins.rs
@@ -1,7 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::{FullFileSource, Span, Token, TokenKind};
 
-
 #[test]
 fn parses_builtin_function_in_macro_body() {
     let builtin_funcs = [

--- a/huff_lexer/tests/builtins.rs
+++ b/huff_lexer/tests/builtins.rs
@@ -1,6 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::{FullFileSource, Span, Token, TokenKind};
-use std::ops::Deref;
+
 
 #[test]
 fn parses_builtin_function_in_macro_body() {

--- a/huff_lexer/tests/comments.rs
+++ b/huff_lexer/tests/comments.rs
@@ -1,6 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::*;
-use std::ops::Deref;
+
 
 // use proptest::prelude::*;
 
@@ -37,31 +37,31 @@ fn single_line_comments() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(20..20, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, define_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, define_span));
 
     // This token should be a Define identifier
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(21..27, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(28..28, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, define_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, define_span));
 
     // Then we should parse the macro keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let macro_span = Span::new(29..33, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Macro, macro_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Macro, macro_span));
 
     // The next token should be another whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let ws_span = Span::new(34..34, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, ws_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, ws_span));
 
     // Then we should get the function name
     let tok = lexer.next();
@@ -69,25 +69,25 @@ fn single_line_comments() {
     let function_span = Span::new(35..45, None);
     assert_eq!(
         unwrapped,
-        Token::new(TokenKind::Ident("HELLO_WORLD".to_string()), function_span.clone())
+        Token::new(TokenKind::Ident("HELLO_WORLD".to_string()), function_span)
     );
 
     // Then we should have an open paren
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let open_paren_span = Span::new(46..46, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::OpenParen, open_paren_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::OpenParen, open_paren_span));
 
     // Lastly, we should have a closing parenthesis
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let close_paren_span = Span::new(47..47, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::CloseParen, close_paren_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::CloseParen, close_paren_span));
 
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let eof_span = Span::new(47..47, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Eof, eof_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Eof, eof_span));
 
     // We covered the whole source
     assert!(lexer.eof);
@@ -112,25 +112,25 @@ fn multi_line_comments() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(21..27, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(28..28, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, define_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, define_span));
 
     // Then we should parse the macro keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let macro_span = Span::new(29..33, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Macro, macro_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Macro, macro_span));
 
     // The next token should be another whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let ws_span = Span::new(34..34, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, ws_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, ws_span));
 
     // Then we should get the function name
     let tok = lexer.next();
@@ -138,25 +138,25 @@ fn multi_line_comments() {
     let function_span = Span::new(35..45, None);
     assert_eq!(
         unwrapped,
-        Token::new(TokenKind::Ident("HELLO_WORLD".to_string()), function_span.clone())
+        Token::new(TokenKind::Ident("HELLO_WORLD".to_string()), function_span)
     );
 
     // Then we should have an open paren
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let open_paren_span = Span::new(46..46, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::OpenParen, open_paren_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::OpenParen, open_paren_span));
 
     // Lastly, we should have a closing parenthesis
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let close_paren_span = Span::new(47..47, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::CloseParen, close_paren_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::CloseParen, close_paren_span));
 
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let eof_span = Span::new(47..47, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Eof, eof_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Eof, eof_span));
 
     // We covered the whole source
     assert!(lexer.eof);

--- a/huff_lexer/tests/comments.rs
+++ b/huff_lexer/tests/comments.rs
@@ -1,7 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::*;
 
-
 // use proptest::prelude::*;
 
 // proptest! {
@@ -67,10 +66,7 @@ fn single_line_comments() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let function_span = Span::new(35..45, None);
-    assert_eq!(
-        unwrapped,
-        Token::new(TokenKind::Ident("HELLO_WORLD".to_string()), function_span)
-    );
+    assert_eq!(unwrapped, Token::new(TokenKind::Ident("HELLO_WORLD".to_string()), function_span));
 
     // Then we should have an open paren
     let tok = lexer.next();
@@ -136,10 +132,7 @@ fn multi_line_comments() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let function_span = Span::new(35..45, None);
-    assert_eq!(
-        unwrapped,
-        Token::new(TokenKind::Ident("HELLO_WORLD".to_string()), function_span)
-    );
+    assert_eq!(unwrapped, Token::new(TokenKind::Ident("HELLO_WORLD".to_string()), function_span));
 
     // Then we should have an open paren
     let tok = lexer.next();

--- a/huff_lexer/tests/decorators.rs
+++ b/huff_lexer/tests/decorators.rs
@@ -1,7 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::{str_to_bytes32, FullFileSource, Span, Token, TokenKind};
 
-
 #[test]
 fn parses_decorator() {
     let key_words = ["macro", "fn", "test"];

--- a/huff_lexer/tests/decorators.rs
+++ b/huff_lexer/tests/decorators.rs
@@ -1,6 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::{str_to_bytes32, FullFileSource, Span, Token, TokenKind};
-use std::ops::Deref;
+
 
 #[test]
 fn parses_decorator() {

--- a/huff_lexer/tests/eof.rs
+++ b/huff_lexer/tests/eof.rs
@@ -1,7 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::*;
 
-
 #[test]
 fn end_of_file() {
     let source = " ";

--- a/huff_lexer/tests/eof.rs
+++ b/huff_lexer/tests/eof.rs
@@ -1,6 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::*;
-use std::ops::Deref;
+
 
 #[test]
 fn end_of_file() {

--- a/huff_lexer/tests/fsp.rs
+++ b/huff_lexer/tests/fsp.rs
@@ -1,7 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::*;
 
-
 #[test]
 fn free_storage_pointer() {
     let source = "FREE_STORAGE_POINTER() ";

--- a/huff_lexer/tests/fsp.rs
+++ b/huff_lexer/tests/fsp.rs
@@ -1,7 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::*;
-/// Tests lexing the Free Storage Pointer Keyword
-use std::ops::Deref;
+
 
 #[test]
 fn free_storage_pointer() {

--- a/huff_lexer/tests/function_type.rs
+++ b/huff_lexer/tests/function_type.rs
@@ -1,7 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::*;
 
-
 #[test]
 fn parses_function_type() {
     let fn_types = [

--- a/huff_lexer/tests/function_type.rs
+++ b/huff_lexer/tests/function_type.rs
@@ -1,6 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::*;
-use std::ops::Deref;
+
 
 #[test]
 fn parses_function_type() {

--- a/huff_lexer/tests/hex.rs
+++ b/huff_lexer/tests/hex.rs
@@ -1,6 +1,5 @@
-use huff_lexer::{Lexer};
+use huff_lexer::Lexer;
 use huff_utils::prelude::*;
-
 
 #[test]
 fn parses_single_hex() {

--- a/huff_lexer/tests/hex.rs
+++ b/huff_lexer/tests/hex.rs
@@ -1,6 +1,6 @@
-use huff_lexer::{Lexer, *};
+use huff_lexer::{Lexer};
 use huff_utils::prelude::*;
-use std::ops::Deref;
+
 
 #[test]
 fn parses_single_hex() {

--- a/huff_lexer/tests/imports.rs
+++ b/huff_lexer/tests/imports.rs
@@ -1,7 +1,6 @@
 use huff_lexer::Lexer;
 use huff_utils::prelude::*;
 
-
 #[test]
 fn single_lex_imports() {
     let import_str = "../huff-examples/erc20/contracts/utils/Ownable.huff";

--- a/huff_lexer/tests/imports.rs
+++ b/huff_lexer/tests/imports.rs
@@ -1,6 +1,6 @@
 use huff_lexer::Lexer;
 use huff_utils::prelude::*;
-use std::ops::Deref;
+
 
 #[test]
 fn single_lex_imports() {
@@ -120,7 +120,7 @@ fn include_with_string() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let literal_span = Span::new(8..8, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, literal_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, literal_span));
 
     // Then we should parse the string literal
     let tok = lexer.next();
@@ -130,7 +130,7 @@ fn include_with_string() {
         unwrapped,
         Token::new(
             TokenKind::Str("../huff-examples/erc20/contracts/utils/Ownable.huff".to_string()),
-            literal_span.clone()
+            literal_span
         )
     );
 
@@ -155,7 +155,7 @@ fn include_with_string_single_quote() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let literal_span = Span::new(8..8, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, literal_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, literal_span));
 
     // Then we should parse the string literal
     let tok = lexer.next();
@@ -165,7 +165,7 @@ fn include_with_string_single_quote() {
         unwrapped,
         Token::new(
             TokenKind::Str("../huff-examples/erc20/contracts/utils/Ownable.huff".to_string()),
-            literal_span.clone()
+            literal_span
         )
     );
 

--- a/huff_lexer/tests/keywords.rs
+++ b/huff_lexer/tests/keywords.rs
@@ -1,7 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::*;
 
-
 #[test]
 fn parses_macro_keyword() {
     let source = "#define macro";

--- a/huff_lexer/tests/keywords.rs
+++ b/huff_lexer/tests/keywords.rs
@@ -1,6 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::*;
-use std::ops::Deref;
+
 
 #[test]
 fn parses_macro_keyword() {
@@ -12,19 +12,19 @@ fn parses_macro_keyword() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(0..6, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let whitespace_span = Span::new(7..7, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span));
 
     // Lastly we should parse the macro keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let macro_span = Span::new(8..12, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Macro, macro_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Macro, macro_span));
 
     lexer.next();
 
@@ -42,19 +42,19 @@ fn parses_fn_keyword() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(0..6, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let whitespace_span = Span::new(7..7, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span));
 
     // Lastly we should parse the fn keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let fn_span = Span::new(8..9, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Fn, fn_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Fn, fn_span));
 
     lexer.next();
 
@@ -72,19 +72,19 @@ fn parses_test_keyword() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(0..6, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let whitespace_span = Span::new(7..7, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span));
 
     // Lastly we should parse the fn keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let test_span = Span::new(8..11, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Test, test_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Test, test_span));
 
     lexer.next();
 
@@ -102,19 +102,19 @@ fn parses_function_keyword() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(0..6, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let whitespace_span = Span::new(7..7, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span));
 
     // Lastly we should parse the function keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let function_span = Span::new(8..15, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Function, function_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Function, function_span));
 
     lexer.next();
 
@@ -132,19 +132,19 @@ fn parses_event_keyword() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(0..6, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let whitespace_span = Span::new(7..7, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span));
 
     // Lastly we should parse the event keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let event_span = Span::new(8..12, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Event, event_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Event, event_span));
 
     let _ = lexer.next(); // whitespace
     let _ = lexer.next(); // event name
@@ -167,19 +167,19 @@ fn parses_constant_keyword() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(0..6, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let whitespace_span = Span::new(7..7, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span));
 
     // Lastly we should parse the constant keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let constant_span = Span::new(8..15, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Constant, constant_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Constant, constant_span));
 
     lexer.next();
 
@@ -208,7 +208,7 @@ fn parses_takes_and_returns_keywords() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let takes_span = Span::new(23..27, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Takes, takes_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Takes, takes_span));
 
     // Lex the middle 5 chars
     let _ = lexer.next(); // whitespace
@@ -221,7 +221,7 @@ fn parses_takes_and_returns_keywords() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let returns_span = Span::new(37..43, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Returns, returns_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Returns, returns_span));
 
     // Lex the last 4 chars
     let _ = lexer.next(); // whitespace
@@ -255,7 +255,7 @@ fn parses_takes_and_returns_keywords_tight_syntax() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let takes_span = Span::new(23..27, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Takes, takes_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Takes, takes_span));
 
     // Lex the next 4 chars
     let _ = lexer.next(); // open parenthesis
@@ -267,7 +267,7 @@ fn parses_takes_and_returns_keywords_tight_syntax() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let returns_span = Span::new(32..38, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Returns, returns_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Returns, returns_span));
 
     // Lex the last 3 chars
     let _ = lexer.next(); // open parenthesis
@@ -297,7 +297,7 @@ fn parses_function_type_keywords() {
     // Lex view first
     let tok = lexer.next().unwrap().unwrap();
     let view_span = Span::new(24..27, None);
-    assert_eq!(tok, Token::new(TokenKind::View, view_span.clone()));
+    assert_eq!(tok, Token::new(TokenKind::View, view_span));
 
     // Lex the next 4 chars
     let _ = lexer.next(); // whitespace
@@ -644,7 +644,7 @@ fn parses_takes_keyword_arbitrary_whitespace() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let takes_span = Span::new(28..32, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Takes, takes_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Takes, takes_span));
 
     // Lex the middle 5 chars
     let _ = lexer.next(); // whitespace
@@ -657,7 +657,7 @@ fn parses_takes_keyword_arbitrary_whitespace() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let returns_span = Span::new(38..44, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Returns, returns_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Returns, returns_span));
 
     // Lex the last 4 chars
     let _ = lexer.next(); // whitespace

--- a/huff_lexer/tests/numbers.rs
+++ b/huff_lexer/tests/numbers.rs
@@ -1,6 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::*;
-use std::ops::Deref;
+
 
 #[test]
 fn lexes_zero_prefixed_numbers() {

--- a/huff_lexer/tests/numbers.rs
+++ b/huff_lexer/tests/numbers.rs
@@ -1,7 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::*;
 
-
 #[test]
 fn lexes_zero_prefixed_numbers() {
     let source = "00";

--- a/huff_lexer/tests/symbols.rs
+++ b/huff_lexer/tests/symbols.rs
@@ -1,6 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::*;
-use std::ops::Deref;
+
 
 #[test]
 fn lexes_assign_op() {
@@ -12,25 +12,25 @@ fn lexes_assign_op() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(0..6, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(7..7, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, define_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, define_span));
 
     // Then we should parse the constant keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let constant_span = Span::new(8..15, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Constant, constant_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Constant, constant_span));
 
     // The next token should be another whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let ws_span = Span::new(16..16, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, ws_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, ws_span));
 
     // Then we should get the function name
     let tok = lexer.next();
@@ -38,20 +38,20 @@ fn lexes_assign_op() {
     let function_span = Span::new(17..40, None);
     assert_eq!(
         unwrapped,
-        Token::new(TokenKind::Ident("TRANSFER_EVENT_SIGNATURE".to_string()), function_span.clone())
+        Token::new(TokenKind::Ident("TRANSFER_EVENT_SIGNATURE".to_string()), function_span)
     );
 
     // Then we should have another whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let whitespace_span = Span::new(41..41, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span));
 
     // Finally, we have our assign operator
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let assign_span = Span::new(42..42, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Assign, assign_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Assign, assign_span));
     lexer.next();
 
     // We covered the whole source
@@ -68,7 +68,7 @@ fn lexes_brackets() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let bracket_span = Span::new(0..0, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::OpenBracket, bracket_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::OpenBracket, bracket_span));
 
     // The next token should be the location identifier
     let tok = lexer.next();
@@ -76,14 +76,14 @@ fn lexes_brackets() {
     let loc_span = Span::new(1..21, None);
     assert_eq!(
         unwrapped,
-        Token::new(TokenKind::Ident("TOTAL_SUPPLY_LOCATION".to_string()), loc_span.clone())
+        Token::new(TokenKind::Ident("TOTAL_SUPPLY_LOCATION".to_string()), loc_span)
     );
 
     // Then we should parse the closing bracket
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let bracket_span = Span::new(22..22, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::CloseBracket, bracket_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::CloseBracket, bracket_span));
 
     // Eat the last tokens
     let _ = lexer.next(); // whitespace
@@ -134,7 +134,7 @@ fn lexes_braces() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let brace_span = Span::new(51..51, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::OpenBrace, brace_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::OpenBrace, brace_span));
 
     // Eat the characters in between braces
     let _ = lexer.next(); // whitespace
@@ -149,7 +149,7 @@ fn lexes_braces() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let brace_span = Span::new(131..131, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::CloseBrace, brace_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::CloseBrace, brace_span));
 
     // Eat the last whitespace
     let _ = lexer.next(); // whitespace
@@ -174,7 +174,7 @@ fn lexes_math_ops() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let add_span = Span::new(4..4, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Add, add_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Add, add_span));
 
     // Eat the number and whitespaces
     let _ = lexer.next();
@@ -185,7 +185,7 @@ fn lexes_math_ops() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let sub_span = Span::new(9..9, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Sub, sub_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Sub, sub_span));
 
     // Eat the number and whitespaces
     let _ = lexer.next();
@@ -196,7 +196,7 @@ fn lexes_math_ops() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let mul_span = Span::new(14..14, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Mul, mul_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Mul, mul_span));
 
     // Eat the number and whitespace
     let _ = lexer.next();
@@ -207,7 +207,7 @@ fn lexes_math_ops() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let div_span = Span::new(18..18, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Div, div_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Div, div_span));
 
     // Eat the number and whitespace
     let _ = lexer.next();
@@ -230,7 +230,7 @@ fn lexes_commas() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let comma_span = Span::new(4..4, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Comma, comma_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Comma, comma_span));
 
     // Eat alphanumerics
     let _ = lexer.next();
@@ -253,7 +253,7 @@ fn lexes_comma_sparse() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let comma_span = Span::new(5..5, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Comma, comma_span.clone()));
+    assert_eq!(unwrapped, Token::new(TokenKind::Comma, comma_span));
 
     let _ = lexer.next(); // whitespace
     let _ = lexer.next(); // alphanumerics

--- a/huff_lexer/tests/symbols.rs
+++ b/huff_lexer/tests/symbols.rs
@@ -1,7 +1,6 @@
 use huff_lexer::*;
 use huff_utils::prelude::*;
 
-
 #[test]
 fn lexes_assign_op() {
     let source = "#define constant TRANSFER_EVENT_SIGNATURE =";

--- a/huff_parser/src/lib.rs
+++ b/huff_parser/src/lib.rs
@@ -224,7 +224,7 @@ impl Parser {
 
     /// Parses a function.
     /// Adheres to <https://github.com/huff-language/huffc/blob/master/src/parser/high-level.ts#L87-L111>
-    pub fn parse_function(&mut self) -> Result<Function, ParserError> {
+    pub fn parse_function(&mut self) -> Result<FunctionDefinition, ParserError> {
         // the first token should be of `TokenKind::Function`
         self.match_kind(TokenKind::Function)?;
         // function name should be next
@@ -273,7 +273,7 @@ impl Parser {
             inputs.iter().map(|i| i.arg_type.as_ref().unwrap().clone()).collect::<Vec<_>>();
         hash_bytes(&mut signature, &format!("{name}({})", input_types.join(",")));
 
-        Ok(Function {
+        Ok(FunctionDefinition {
             name,
             signature,
             inputs,
@@ -284,7 +284,7 @@ impl Parser {
     }
 
     /// Parse an event.
-    pub fn parse_event(&mut self) -> Result<Event, ParserError> {
+    pub fn parse_event(&mut self) -> Result<EventDefinition, ParserError> {
         // The event should start with `TokenKind::Event`
         self.match_kind(TokenKind::Event)?;
 
@@ -312,7 +312,7 @@ impl Parser {
             parameters.iter().map(|i| i.arg_type.as_ref().unwrap().clone()).collect::<Vec<_>>();
         hash_bytes(&mut hash, &format!("{name}({})", input_types.join(",")));
 
-        Ok(Event { name, parameters, span: AstSpan(self.spans.clone()), hash })
+        Ok(EventDefinition { name, parameters, span: AstSpan(self.spans.clone()), hash })
     }
 
     /// Parse a constant.

--- a/huff_parser/tests/event.rs
+++ b/huff_parser/tests/event.rs
@@ -1,6 +1,6 @@
 use huff_lexer::*;
 use huff_parser::*;
-use huff_utils::{ast::Event, prelude::*};
+use huff_utils::{ast::EventDefinition, prelude::*};
 
 #[test]
 fn test_prefix_event_arg_names_with_reserved_keywords() {
@@ -75,7 +75,7 @@ fn test_parse_event() {
     let sources = [
         (
             "#define event TestEvent(uint256 indexed a,uint8 indexed)",
-            Event {
+            EventDefinition {
                 name: "TestEvent".to_string(),
                 parameters: vec![
                     Argument {
@@ -137,7 +137,7 @@ fn test_parse_event() {
         ),
         (
             "#define event TestEvent(uint256,uint8 b)",
-            Event {
+            EventDefinition {
                 name: "TestEvent".to_string(),
                 parameters: vec![
                     Argument {
@@ -191,7 +191,7 @@ fn test_parse_event() {
         ),
         (
             "#define event TestEvent(uint256 indexed,uint8)",
-            Event {
+            EventDefinition {
                 name: "TestEvent".to_string(),
                 parameters: vec![
                     Argument {

--- a/huff_parser/tests/function.rs
+++ b/huff_parser/tests/function.rs
@@ -1,7 +1,7 @@
 use huff_lexer::*;
 use huff_parser::*;
 use huff_utils::{
-    ast::{Function, FunctionType},
+    ast::{FunctionDefinition, FunctionType},
     prelude::*,
 };
 use std::collections::HashMap;
@@ -17,7 +17,7 @@ fn parses_valid_function_definition() {
     let expected_fns = HashMap::from([
         (
             0,
-            Function {
+            FunctionDefinition {
                 name: "test".to_string(),
                 inputs: vec![
                     Argument {
@@ -67,7 +67,7 @@ fn parses_valid_function_definition() {
         ),
         (
             1,
-            Function {
+            FunctionDefinition {
                 name: "test".to_string(),
                 inputs: vec![Argument {
                     name: None,
@@ -102,7 +102,7 @@ fn parses_valid_function_definition() {
         ),
         (
             2,
-            Function {
+            FunctionDefinition {
                 name: "test".to_string(),
                 inputs: vec![Argument {
                     name: None,
@@ -137,7 +137,7 @@ fn parses_valid_function_definition() {
         ),
         (
             3,
-            Function {
+            FunctionDefinition {
                 name: "test".to_string(),
                 inputs: vec![Argument {
                     name: None,
@@ -172,7 +172,7 @@ fn parses_valid_function_definition() {
         ),
         (
             4,
-            Function {
+            FunctionDefinition {
                 name: "test".to_string(),
                 inputs: vec![Argument {
                     name: None,

--- a/huff_parser/tests/macro.rs
+++ b/huff_parser/tests/macro.rs
@@ -1,7 +1,6 @@
-use huff_lexer::{Lexer};
+use huff_lexer::Lexer;
 use huff_parser::*;
 use huff_utils::{evm::Opcode, prelude::*};
-
 
 #[test]
 fn empty_macro() {

--- a/huff_parser/tests/macro.rs
+++ b/huff_parser/tests/macro.rs
@@ -1,7 +1,7 @@
-use huff_lexer::{Lexer, *};
+use huff_lexer::{Lexer};
 use huff_parser::*;
 use huff_utils::{evm::Opcode, prelude::*};
-use tracing::debug;
+
 
 #[test]
 fn empty_macro() {

--- a/huff_utils/src/abi.rs
+++ b/huff_utils/src/abi.rs
@@ -77,7 +77,7 @@ impl From<ast::Contract> for Abi {
             .iter()
             .filter(|m| m.name.to_lowercase() == "constructor")
             .cloned()
-            .collect::<Vec<ast::Function>>()
+            .collect::<Vec<ast::FunctionDefinition>>()
             .get(0)
             .map(|func| Constructor {
                 inputs: func
@@ -122,7 +122,7 @@ impl From<ast::Contract> for Abi {
             contract
                 .functions
                 .iter()
-                .filter(|function: &&ast::Function| function.name != "CONSTRUCTOR")
+                .filter(|function: &&ast::FunctionDefinition| function.name != "CONSTRUCTOR")
                 .map(|function| {
                     (
                         function.name.to_string(),

--- a/huff_utils/src/abi.rs
+++ b/huff_utils/src/abi.rs
@@ -20,7 +20,7 @@
 //!     imports: vec![],
 //!     constants: Arc::new(Mutex::new(vec![])),
 //!     errors: vec![],
-//!     functions: vec![huff_utils::ast::Function {
+//!     functions: vec![huff_utils::ast::FunctionDefinition {
 //!         name: "CONSTRUCTOR".to_string(),
 //!         signature: [0u8, 0u8, 0u8, 0u8],
 //!         inputs: vec![],

--- a/huff_utils/src/ast.rs
+++ b/huff_utils/src/ast.rs
@@ -97,9 +97,9 @@ pub struct Contract {
     /// Custom Errors
     pub errors: Vec<ErrorDefinition>,
     /// Functions
-    pub functions: Vec<Function>,
+    pub functions: Vec<FunctionDefinition>,
     /// Events
-    pub events: Vec<Event>,
+    pub events: Vec<EventDefinition>,
     /// Tables
     pub tables: Vec<TableDefinition>,
 }
@@ -419,7 +419,7 @@ pub struct Argument {
 
 /// A Function Signature
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Function {
+pub struct FunctionDefinition {
     /// The name of the function
     pub name: String,
     /// The function signature
@@ -461,7 +461,7 @@ impl FunctionType {
 
 /// An Event Signature
 #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Event {
+pub struct EventDefinition {
     /// The name of the event
     pub name: String,
     /// The parameters of the event


### PR DESCRIPTION
## Overview

A clippy update has added a lint for ambiguous exports, where two modules export an entity with the same name. In this case, `Function` and `Event` were both exported from `ast.rs` and `abi.rs`. 

To resolve the issue I have renamed to ast items to be appended with `Definition`, lining up with naming of `TableDefinition` etc seen elsewhere within the module. 

<!--
Thank you for creating a Pull Request!
Please provide a short description here and review the requirements below.
Bug fixes and new features should include tests.

Make sure to run these checks before opening a pr!
```sh
cargo check --all
cargo test --all --all-features
cargo +nightly fmt -- --check
cargo +nightly clippy --all --all-features -- -D warnings
```

Recommended method to auto format your code before pushing:
```sh
cargo +nightly fmt --all
```
-->
