### PR TITLE
Make Codegen Faster Through Less Allocations

### DIFF
--- a/huff_codegen/src/irgen/arg_calls.rs
+++ b/huff_codegen/src/irgen/arg_calls.rs
@@ -11,9 +11,9 @@ use std::str::FromStr;
 pub fn bubble_arg_call(
     arg_name: &str,
     bytes: &mut Vec<(usize, Bytes)>,
-    macro_def: MacroDefinition,
+    macro_def: &MacroDefinition,
     contract: &Contract,
-    scope: &mut [MacroDefinition],
+    scope: &mut [&MacroDefinition],
     offset: &mut usize,
     // mis: Parent macro invocations and their indices
     mis: &mut [(usize, MacroInvocation)],

--- a/huff_codegen/src/irgen/arg_calls.rs
+++ b/huff_codegen/src/irgen/arg_calls.rs
@@ -47,8 +47,8 @@ pub fn bubble_arg_call(
                         tracing::info!(target: "codegen", "GOT ARG CALL \"{}\" ARG FROM MACRO INVOCATION", ac);
                         tracing::debug!(target: "codegen", "~~~ BUBBLING UP ARG CALL");
                         let scope_len = scope.len();
-                        let mut new_scope = &mut scope[..scope_len.saturating_sub(1)];
-                        let bubbled_macro_invocation = new_scope.last().unwrap().clone();
+                        let new_scope = &mut scope[..scope_len.saturating_sub(1)];
+                        let bubbled_macro_invocation = new_scope.last().unwrap();
                         tracing::debug!(target: "codegen", "BUBBLING UP WITH MACRO DEF: {}", &bubbled_macro_invocation.name);
                         tracing::debug!(target: "codegen", "CURRENT MACRO DEF: {}", macro_def.name);
 
@@ -73,7 +73,7 @@ pub fn bubble_arg_call(
                                 bytes,
                                 bubbled_macro_invocation,
                                 contract,
-                                &mut new_scope,
+                                new_scope,
                                 offset,
                                 &mut mis[..mis_len.saturating_sub(1)],
                                 jump_table,
@@ -84,7 +84,7 @@ pub fn bubble_arg_call(
                                 bytes,
                                 bubbled_macro_invocation,
                                 contract,
-                                &mut new_scope,
+                                new_scope,
                                 offset,
                                 mis,
                                 jump_table,

--- a/huff_codegen/src/irgen/arg_calls.rs
+++ b/huff_codegen/src/irgen/arg_calls.rs
@@ -11,12 +11,12 @@ use std::str::FromStr;
 pub fn bubble_arg_call(
     arg_name: &str,
     bytes: &mut Vec<(usize, Bytes)>,
-    macro_def: &MacroDefinition,
+    macro_def: MacroDefinition,
     contract: &Contract,
-    scope: &mut Vec<MacroDefinition>,
+    scope: &mut [MacroDefinition],
     offset: &mut usize,
     // mis: Parent macro invocations and their indices
-    mis: &mut Vec<(usize, MacroInvocation)>,
+    mis: &mut [(usize, MacroInvocation)],
     jump_table: &mut JumpTable,
 ) -> Result<(), CodegenError> {
     let starting_offset = *offset;
@@ -46,9 +46,10 @@ pub fn bubble_arg_call(
                     MacroArg::ArgCall(ac) => {
                         tracing::info!(target: "codegen", "GOT ARG CALL \"{}\" ARG FROM MACRO INVOCATION", ac);
                         tracing::debug!(target: "codegen", "~~~ BUBBLING UP ARG CALL");
-                        let mut new_scope = Vec::from(&scope[..scope.len().saturating_sub(1)]);
+                        let scope_len = scope.len();
+                        let mut new_scope = &mut scope[..scope_len.saturating_sub(1)];
                         let bubbled_macro_invocation = new_scope.last().unwrap().clone();
-                        tracing::debug!(target: "codegen", "BUBBLING UP WITH MACRO DEF: {}", bubbled_macro_invocation.name);
+                        tracing::debug!(target: "codegen", "BUBBLING UP WITH MACRO DEF: {}", &bubbled_macro_invocation.name);
                         tracing::debug!(target: "codegen", "CURRENT MACRO DEF: {}", macro_def.name);
 
                         // Only remove an invocation if not at bottom level, otherwise we'll
@@ -60,27 +61,28 @@ pub fn bubble_arg_call(
                                     kind: CodegenErrorKind::MissingMacroInvocation(
                                         macro_def.name.clone(),
                                     ),
-                                    span: bubbled_macro_invocation.span,
+                                    span: bubbled_macro_invocation.span.clone(),
                                     token: None,
                                 })
                             }
                         };
+                        let mis_len = mis.len();
                         return if last_mi.1.macro_name.eq(&macro_def.name) {
                             bubble_arg_call(
                                 arg_name,
                                 bytes,
-                                &bubbled_macro_invocation,
+                                bubbled_macro_invocation,
                                 contract,
                                 &mut new_scope,
                                 offset,
-                                &mut Vec::from(&mis[..mis.len().saturating_sub(1)]),
+                                &mut mis[..mis_len.saturating_sub(1)],
                                 jump_table,
                             )
                         } else {
                             bubble_arg_call(
                                 arg_name,
                                 bytes,
-                                &bubbled_macro_invocation,
+                                bubbled_macro_invocation,
                                 contract,
                                 &mut new_scope,
                                 offset,

--- a/huff_codegen/src/irgen/constants.rs
+++ b/huff_codegen/src/irgen/constants.rs
@@ -6,7 +6,7 @@ use huff_utils::prelude::{
 pub fn constant_gen(
     name: &str,
     contract: &Contract,
-    ir_byte_span: AstSpan,
+    ir_byte_span: &AstSpan,
 ) -> Result<String, CodegenError> {
     // Get the first `ConstantDefinition` that matches the constant's name
     let constants = contract
@@ -20,7 +20,7 @@ pub fn constant_gen(
 
         return Err(CodegenError {
             kind: CodegenErrorKind::MissingConstantDefinition(name.to_string()),
-            span: ir_byte_span,
+            span: ir_byte_span.clone(),
             token: None,
         })
     };

--- a/huff_codegen/src/irgen/statements.rs
+++ b/huff_codegen/src/irgen/statements.rs
@@ -4,11 +4,11 @@ use crate::Codegen;
 
 /// Generates the respective Bytecode for a given Statement
 #[allow(clippy::too_many_arguments)]
-pub fn statement_gen(
+pub fn statement_gen<'a>(
     s: &Statement,
-    contract: &Contract,
+    contract: &'a Contract,
     macro_def: &MacroDefinition,
-    scope: &mut Vec<MacroDefinition>,
+    scope: &mut Vec<&'a MacroDefinition>,
     offset: &mut usize,
     mis: &mut Vec<(usize, MacroInvocation)>,
     jump_table: &mut JumpTable,
@@ -93,7 +93,7 @@ pub fn statement_gen(
                 *offset += stack_swaps.len() + 8;
             } else {
                 // Recurse into macro invocation
-                scope.push(ir_macro.clone());
+                scope.push(ir_macro);
                 mis.push((*offset, mi.clone()));
 
                 let mut res: BytecodeRes = match Codegen::macro_to_bytecode(

--- a/huff_codegen/src/irgen/statements.rs
+++ b/huff_codegen/src/irgen/statements.rs
@@ -47,7 +47,7 @@ pub fn statement_gen(
                 tracing::error!(target: "codegen", "Tests may not be invoked: {}", ir_macro.name);
                 return Err(CodegenError {
                     kind: CodegenErrorKind::TestInvocation(ir_macro.name.clone()),
-                    span: ir_macro.span,
+                    span: ir_macro.span.clone(),
                     token: None,
                 })
             }
@@ -97,7 +97,7 @@ pub fn statement_gen(
                 mis.push((*offset, mi.clone()));
 
                 let mut res: BytecodeRes = match Codegen::macro_to_bytecode(
-                    ir_macro.clone(),
+                    ir_macro,
                     contract,
                     scope,
                     *offset,
@@ -205,7 +205,7 @@ pub fn statement_gen(
                     } else {
                         // We will still need to recurse to get accurate values
                         let res: BytecodeRes = match Codegen::macro_to_bytecode(
-                            ir_macro.clone(),
+                            ir_macro,
                             contract,
                             scope,
                             *offset,

--- a/huff_codegen/src/lib.rs
+++ b/huff_codegen/src/lib.rs
@@ -335,7 +335,7 @@ impl Codegen {
                     bubble_arg_call(
                         &arg_name,
                         &mut bytes,
-                        &macro_def,
+                        macro_def.clone(),
                         contract,
                         scope,
                         &mut offset,

--- a/huff_codegen/src/lib.rs
+++ b/huff_codegen/src/lib.rs
@@ -69,7 +69,7 @@ impl Codegen {
         let bytecode_res: BytecodeRes = Codegen::macro_to_bytecode(
             m_macro,
             contract,
-            &mut vec![m_macro.clone()],
+            &mut vec![m_macro],
             0,
             &mut Vec::default(),
             false,
@@ -98,7 +98,7 @@ impl Codegen {
         let bytecode_res: BytecodeRes = Codegen::macro_to_bytecode(
             c_macro,
             contract,
-            &mut vec![c_macro.clone()],
+            &mut vec![c_macro],
             0,
             &mut Vec::default(),
             false,
@@ -272,10 +272,10 @@ impl Codegen {
     /// * `scope` - Current scope of the recursion. Contains all macro definitions recursed so far.
     /// * `offset` - Current bytecode offset
     /// * `mis` - Vector of tuples containing parent macro invocations as well as their offsets.
-    pub fn macro_to_bytecode(
-        macro_def: &MacroDefinition,
-        contract: &Contract,
-        scope: &mut Vec<MacroDefinition>,
+    pub fn macro_to_bytecode<'a>(
+        macro_def: &'a MacroDefinition,
+        contract: &'a Contract,
+        scope: &mut Vec<&'a MacroDefinition>,
         mut offset: usize,
         mis: &mut Vec<(usize, MacroInvocation)>,
         recursing_constructor: bool,
@@ -316,7 +316,7 @@ impl Codegen {
                     let mut push_bytes = statement_gen(
                         &s,
                         contract,
-                        &macro_def,
+                        macro_def,
                         scope,
                         &mut offset,
                         mis,
@@ -335,7 +335,7 @@ impl Codegen {
                     bubble_arg_call(
                         &arg_name,
                         &mut bytes,
-                        macro_def.clone(),
+                        macro_def,
                         contract,
                         scope,
                         &mut offset,
@@ -534,9 +534,9 @@ impl Codegen {
     /// On success, passes ownership of `bytes` back to the caller.
     /// On failure, returns a CodegenError.
     #[allow(clippy::too_many_arguments)]
-    pub fn append_functions(
-        contract: &Contract,
-        scope: &mut Vec<MacroDefinition>,
+    pub fn append_functions<'a>(
+        contract: &'a Contract,
+        scope: &mut Vec<&'a MacroDefinition>,
         offset: &mut usize,
         mis: &mut Vec<(usize, MacroInvocation)>,
         jump_table: &mut JumpTable,
@@ -546,7 +546,7 @@ impl Codegen {
     ) -> Result<Vec<(usize, Bytes)>, CodegenError> {
         for macro_def in contract.macros.iter().filter(|m| m.outlined) {
             // Push the function to the scope
-            scope.push(macro_def.clone());
+            scope.push(macro_def);
 
             // Add 1 to starting offset to account for the JUMPDEST opcode
             let mut res = Codegen::macro_to_bytecode(

--- a/huff_codegen/src/lib.rs
+++ b/huff_codegen/src/lib.rs
@@ -302,7 +302,7 @@ impl Codegen {
                     bytes.push((starting_offset, b.to_owned()));
                 }
                 IRByteType::Constant(name) => {
-                    let push_bytes = constant_gen(&name, contract, &ir_byte.span)?;
+                    let push_bytes = constant_gen(name, contract, ir_byte.span)?;
                     offset += push_bytes.len() / 2;
                     tracing::debug!(target: "codegen", "OFFSET: {}, PUSH BYTES: {:?}", offset, push_bytes);
                     bytes.push((starting_offset, Bytes(push_bytes)));
@@ -314,7 +314,7 @@ impl Codegen {
                         continue
                     }
                     let mut push_bytes = statement_gen(
-                        &s,
+                        s,
                         contract,
                         macro_def,
                         scope,
@@ -333,7 +333,7 @@ impl Codegen {
                     // Bubble up arg call by looking through the previous scopes.
                     // Once the arg value is found, add it to `bytes`
                     bubble_arg_call(
-                        &arg_name,
+                        arg_name,
                         &mut bytes,
                         macro_def,
                         contract,

--- a/huff_tests/src/runner.rs
+++ b/huff_tests/src/runner.rs
@@ -174,9 +174,9 @@ impl TestRunner {
 
         // Compile the passed test macro
         match Codegen::macro_to_bytecode(
-            m.to_owned(),
+            m,
             contract,
-            &mut vec![m.to_owned()],
+            &mut vec![m],
             0,
             &mut Vec::default(),
             false,

--- a/huff_utils/src/bytecode.rs
+++ b/huff_utils/src/bytecode.rs
@@ -14,11 +14,11 @@ pub struct Bytes(pub String);
 
 /// Intermediate Bytecode Representation
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct IRBytes {
+pub struct IRBytes<'a> {
     /// The type of IRByte
     pub ty: IRByteType,
     /// The Span of the IRBytes
-    pub span: AstSpan,
+    pub span: &'a AstSpan,
 }
 
 /// IRBytes Type
@@ -36,7 +36,7 @@ pub enum IRByteType {
 
 /// Full Intermediate Bytecode Representation
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct IRBytecode(pub Vec<IRBytes>);
+pub struct IRBytecode<'a>(pub Vec<IRBytes<'a>>);
 
 /// ToIRBytecode
 ///


### PR DESCRIPTION
## Overview
Removed a lot of expensive cloning in favour of passing references in the codegen phase. I tried to do this with minimal refactoring. 
Codegen is about 75% faster now for the erc20 benchmark.

Thanks for @jimjbrettj for introducing my to Huff, this has been fun and educational. 

Before: 
<img width="571" alt="Screen Shot 2023-04-03 at 6 34 41 PM" src="https://user-images.githubusercontent.com/6364934/229643065-7b804d5c-2f02-4bd0-b414-c3e71aa09d07.png">

After:
<img width="554" alt="Screen Shot 2023-04-03 at 6 37 18 PM" src="https://user-images.githubusercontent.com/6364934/229643117-58906f21-9fb4-42e0-8f8b-b1042622ff2f.png">

<!--
Thank you for creating a Pull Request!
Please provide a short description here and review the requirements below.
Bug fixes and new features should include tests.

Make sure to run these checks before opening a pr!
```sh
cargo check --all
cargo test --all --all-features
cargo +nightly fmt -- --check
cargo +nightly clippy --all --all-features -- -D warnings
```

Recommended method to auto format your code before pushing:
```sh
cargo +nightly fmt --all
```
-->
