### PR TITLE
Feat/cli label indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,7 @@ name = "huff_cli"
 version = "0.3.1"
 dependencies = [
  "clap 3.2.23",
+ "comfy-table",
  "ethers-core",
  "huff_codegen",
  "huff_core",

--- a/huff_cli/Cargo.toml
+++ b/huff_cli/Cargo.toml
@@ -17,6 +17,7 @@ huff_core = { path = "../huff_core", version = "0.x.x" }
 huff_codegen = { path = "../huff_codegen", version = "0.x.x" }
 huff_utils = { path = "../huff_utils", version = "0.x.x" }
 huff_tests = { path = "../huff_tests", version = "0.x.x" }
+comfy-table = "6.0.0"
 tracing = "0.1.34"
 ethers-core = "1.0.2"
 yansi = "0.5.1"

--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -243,7 +243,7 @@ fn main() {
                         .join("\n  ");
 
                     println!("\n------ JUMP LABEL INDICES ------");
-                    println!("{}", format!("  {}", label_indices).to_string());
+                    println!("  {}", label_indices);
                     println!("--------------------------------\n")
                 } else {
                     eprintln!(

--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -238,7 +238,7 @@ fn main() {
                     let label_indices = bytecode_res
                         .label_indices
                         .iter()
-                        .map(|(label, index)| format!("{}: 0x{:04x}", label, index))
+                        .map(|(label, index)| format!("{}: {:#04x}", label, index))
                         .collect::<Vec<_>>()
                         .join("\n");
 

--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -160,12 +160,12 @@ fn main() {
                 // Check that constant override argument is valid
                 // Key rule: Alphabetic chars + underscore
                 // Value rule: Valid literal string (0x...)
-                if parts.len() != 2
-                    || parts[0].chars().any(|c| !(c.is_alphabetic() || c == '_'))
-                    || !parts[1].starts_with("0x")
-                    || parts[1][2..].chars().any(|c| {
-                        !(c.is_numeric()
-                            || matches!(c, '\u{0041}'..='\u{0046}' | '\u{0061}'..='\u{0066}'))
+                if parts.len() != 2 ||
+                    parts[0].chars().any(|c| !(c.is_alphabetic() || c == '_')) ||
+                    !parts[1].starts_with("0x") ||
+                    parts[1][2..].chars().any(|c| {
+                        !(c.is_numeric() ||
+                            matches!(c, '\u{0041}'..='\u{0046}' | '\u{0061}'..='\u{0066}'))
                     })
                 {
                     eprintln!("Invalid constant override argument: {}", Paint::red(c.to_string()));
@@ -257,7 +257,7 @@ fn main() {
                 std::process::exit(1);
             }
         }
-        return;
+        return
     }
 
     if let Some(TestCommands::Test { format, match_ }) = cli.test {
@@ -286,7 +286,7 @@ fn main() {
                 std::process::exit(1);
             }
         }
-        return;
+        return
     }
 
     // Create compiling spinner

--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -240,9 +240,11 @@ fn main() {
                         .iter()
                         .map(|(label, index)| format!("{}: {:#04x}", label, index))
                         .collect::<Vec<_>>()
-                        .join("\n");
+                        .join("\n  ");
 
-                    println!("Label indices:\n{}", label_indices);
+                    println!("\n------ JUMP LABEL INDICES ------");
+                    println!("{}", format!("  {}", label_indices).to_string());
+                    println!("--------------------------------\n")
                 } else {
                     eprintln!(
                         "{}",


### PR DESCRIPTION
## Overview

Adds a `huff_cli` flag to print the jump labels and their respective PC offset. Works for the `MAIN` macro.

Closes #231 

## Usage Example

```shell
cargo run ./huff-examples/erc20/contracts/ERC20.huff --label-indices
```

Output:

```text
------ JUMP LABEL INDICES ------
  allowance: 0x18e
  approve: 0x177
  balanceOf: 0x14e
  error: 0xd8
  is_owner: 0xed
  mints: 0xde
  totalSupply: 0x16b
  transfer: 0x48
--------------------------------
```

## Notes / open questions

- The output format (what gets printed by the command) could be better, I'm not sure if there is a standard I should follow, looking for feedback on this
- Is support for the `MAIN` macro sufficient or should this command include all macros?