### PR TITLE
Print `--help` when no arguments provided

### DIFF
--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -127,7 +127,7 @@ pub(crate) fn get_input(prompt: &str) -> String {
 
 fn main() {
     // Into App
-    let app: App = Huff::into_app();
+    let mut app: App = Huff::into_app();
 
     // Parse the command line arguments
     let mut cli = Huff::parse();
@@ -135,6 +135,13 @@ fn main() {
     // Initiate Tracing if Verbose
     if cli.verbose {
         Compiler::init_tracing_subscriber(Some(vec![tracing::Level::DEBUG.into()]));
+    }
+
+    // Check if no argument is provided
+    if cli.path.is_none() {
+        // Print help and exit
+        app.print_help().unwrap();
+        return
     }
 
     // Create compiler from the Huff Args


### PR DESCRIPTION
## Overview

Prints the `--help` subcommand output when no arguments provided to the `huff-rs` binary. 
<!--
Thank you for creating a Pull Request!
Please provide a short description here and review the requirements below.
Bug fixes and new features should include tests.

Make sure to run these checks before opening a pr!
```sh
cargo check --all
cargo test --all --all-features
cargo +nightly fmt -- --check
cargo +nightly clippy --all --all-features -- -D warnings
```

Recommended method to auto format your code before pushing:
```sh
cargo +nightly fmt --all
```
-->
