### PR TITLE
MCOPY opcode (EIP-5656)

### DIFF
--- a/huff_utils/src/evm.rs
+++ b/huff_utils/src/evm.rs
@@ -6,7 +6,7 @@ use strum_macros::EnumString;
 /// They are arranged in a particular order such that all the opcodes that have common
 /// prefixes are ordered by decreasing length to avoid mismatch when lexing.
 /// Example : [origin, or] or [push32, ..., push3]
-pub const OPCODES: [&str; 147] = [
+pub const OPCODES: [&str; 148] = [
     "lt",
     "gt",
     "slt",
@@ -39,6 +39,7 @@ pub const OPCODES: [&str; 147] = [
     "chainid",
     "selfbalance",
     "pop",
+    "mcopy",
     "mload",
     "mstore8",
     "mstore",
@@ -199,6 +200,7 @@ pub static OPCODES_MAP: phf::Map<&'static str, Opcode> = phf_map! {
     "jumpi" => Opcode::Jumpi,
     "pc" => Opcode::Pc,
     "msize" => Opcode::Msize,
+    "mcopy" => Opcode::Mcopy,
     "push0" => Opcode::Push0,
     "push1" => Opcode::Push1,
     "push2" => Opcode::Push2,
@@ -440,6 +442,8 @@ pub enum Opcode {
     Gas,
     /// Marks a valid destination for jumps
     Jumpdest,
+    /// Copies an area of memory from src to dst. Areas can overlap.
+    Mcopy,
     /// Places a zero on top of the stack
     Push0,
     /// Places 1 byte item on top of the stack
@@ -678,6 +682,7 @@ impl Opcode {
             Opcode::Msize => "59",
             Opcode::Gas => "5a",
             Opcode::Jumpdest => "5b",
+            Opcode::Mcopy => "5e",
             Opcode::Push0 => "5f",
             Opcode::Push1 => "60",
             Opcode::Push2 => "61",


### PR DESCRIPTION
## Overview

This PR introduces a new opcode (MCOPY) introduced in [`EIP-5656`](https://eips.ethereum.org/EIPS/eip-5656).

The changes needed seem to be minimal (just added a new variant to the `Opcode` enum in `evm.rs`, so that the parser/bytecodegen will be able to understand the new opcode), but it was a good way to get acquainted with the codebase.


## Checklist

- [x] Added a new opcode `mcopy` at 0x5E. Changes [here](https://github.com/huff-language/huff-rs/blob/f809070738e9675fd9760880698ec60dbc13c7ba/huff_utils/src/evm.rs#L42), [here](https://github.com/huff-language/huff-rs/blob/f809070738e9675fd9760880698ec60dbc13c7ba/huff_utils/src/evm.rs#L203), [here](https://github.com/huff-language/huff-rs/blob/f809070738e9675fd9760880698ec60dbc13c7ba/huff_utils/src/evm.rs#L446) and [here](https://github.com/huff-language/huff-rs/blob/f809070738e9675fd9760880698ec60dbc13c7ba/huff_utils/src/evm.rs#L685) (all in the same file).

## Test

I'd like to add a small test, something as simple as compiling:
``` 
#define macro MAIN() = {
    0x00
    0x00
    0x20
    mcopy
}
```
which becomes `5f5f6020205e`, but I couldn't find the right place to put it (and maybe it's not necessary for such a trivial change).

Anyway, I look forward to your recommendations & corrections, so please, feel free to leave any comments you may have :smiley: 