### PR TITLE
Add support for a `padded` directive

### DIFF
--- a/huff_lexer/src/lib.rs
+++ b/huff_lexer/src/lib.rs
@@ -187,6 +187,7 @@ impl<'a> Lexer<'a> {
                         TokenKind::Indexed,
                         TokenKind::View,
                         TokenKind::Pure,
+                        TokenKind::Padded,
                         // First check for packed jump table
                         TokenKind::JumpTablePacked,
                         // Match with jump table if not
@@ -195,6 +196,7 @@ impl<'a> Lexer<'a> {
                     ];
                     for kind in keys.into_iter() {
                         if self.context == Context::MacroBody {
+                            if word == "padded" { found_kind = Some(TokenKind::Padded) }
                             break
                         }
                         let key = kind.to_string();

--- a/huff_lexer/src/lib.rs
+++ b/huff_lexer/src/lib.rs
@@ -196,7 +196,9 @@ impl<'a> Lexer<'a> {
                     ];
                     for kind in keys.into_iter() {
                         if self.context == Context::MacroBody {
-                            if word == "padded" { found_kind = Some(TokenKind::Padded) }
+                            if word == "padded" {
+                                found_kind = Some(TokenKind::Padded)
+                            }
                             break
                         }
                         let key = kind.to_string();

--- a/huff_lexer/tests/padded.rs
+++ b/huff_lexer/tests/padded.rs
@@ -1,0 +1,16 @@
+use huff_lexer::Lexer;
+use huff_parser::*;
+use huff_utils::{evm::Opcode, prelude::*};
+
+#[cfg(test)]
+use std::println as info;
+
+#[test]
+fn padded_with_simple_body() {
+    let source =
+        "#define macro HELLO_WORLD() = takes(3) returns(0) {\n #define padded(32) {\n 0x00 mstore\n 0x01 0x02 add \n} \n}";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source.source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    println!("{:#?}", tokens);
+}

--- a/huff_lexer/tests/padded.rs
+++ b/huff_lexer/tests/padded.rs
@@ -1,6 +1,5 @@
 use huff_lexer::Lexer;
-use huff_parser::*;
-use huff_utils::{evm::Opcode, prelude::*};
+use huff_utils::prelude::*;
 
 #[cfg(test)]
 use std::println as info;
@@ -8,9 +7,9 @@ use std::println as info;
 #[test]
 fn padded_with_simple_body() {
     let source =
-        "#define macro HELLO_WORLD() = takes(3) returns(0) {\n #define padded(32) {\n 0x00 mstore\n 0x01 0x02 add \n} \n}";
+        "#define macro HELLO_WORLD() = takes(3) returns(0) {\n #define padded(32) {\n 0x00 mstore\n 0x01 0x02 add \n} 0x69 0x69 return\n}";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source.source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
-    println!("{:#?}", tokens);
+    info!("{:#?}", tokens);
 }

--- a/huff_parser/src/lib.rs
+++ b/huff_parser/src/lib.rs
@@ -678,8 +678,6 @@ impl Parser {
                     });
                 }
                 TokenKind::Padded => {
-                    // TODO is curr_spans necessary?
-                    // let curr_spans = vec![self.current_token.span.clone()];
                     let padded_statements = self.parse_padded()?;
                     tracing::info!(target: "parser", "PARSING MACRO BODY : [PADDED CODE BLOCK]");
                     statements.extend(padded_statements);
@@ -724,7 +722,7 @@ impl Parser {
                     padded_block_size,
                     padded_statements.len(),
                 ),
-                hint: None,
+                hint: Some("Ensure the padded block's size is >= than its body's size".to_string()),
                 spans: AstSpan(vec![self.current_token.span.clone()]),
             })
         }
@@ -732,14 +730,7 @@ impl Parser {
         while padded_statements.len() < padded_block_size {
             padded_statements.push(Statement {
                 ty: StatementType::Opcode(Opcode::Stop),
-                span: AstSpan(vec![
-                    self.current_token.span.clone(),
-                    Span {
-                        start: padded_statements.len() + 1,
-                        end: padded_statements.len() + 1,
-                        file: None,
-                    },
-                ]),
+                span: AstSpan(vec![]), // TODO what span do I put here?
             });
         }
 

--- a/huff_parser/tests/padded.rs
+++ b/huff_parser/tests/padded.rs
@@ -1,0 +1,72 @@
+use huff_lexer::Lexer;
+use huff_parser::*;
+use huff_utils::{evm::Opcode, prelude::*};
+
+#[test]
+fn macro_with_simple_body() {
+    let source =
+        "#define macro HELLO_WORLD() = takes(3) returns(0) {\n #define padded(17) {\n 0x00 mstore\n 0x01 0x02 add \n} 0x69 0x69 return\n}";
+    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+    let lexer = Lexer::new(flattened_source.source);
+    let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
+    let mut parser = Parser::new(tokens, None);
+
+    // Grab the first macro
+    let macro_definition = parser.parse().unwrap().macros[0].clone();
+    let expected = MacroDefinition {
+        name: "HELLO_WORLD".to_string(),
+        decorator: None,
+        parameters: vec![],
+        statements: vec![
+            Statement {
+                ty: StatementType::Literal(str_to_bytes32("00")),
+                span: AstSpan(vec![Span { start: 54, end: 55, file: None }]),
+            },
+            Statement {
+                ty: StatementType::Opcode(Opcode::Mstore),
+                span: AstSpan(vec![Span { start: 57, end: 62, file: None }]),
+            },
+            Statement {
+                ty: StatementType::Literal(str_to_bytes32("01")),
+                span: AstSpan(vec![Span { start: 67, end: 68, file: None }]),
+            },
+            Statement {
+                ty: StatementType::Literal(str_to_bytes32("02")),
+                span: AstSpan(vec![Span { start: 72, end: 73, file: None }]),
+            },
+            Statement {
+                ty: StatementType::Opcode(Opcode::Add),
+                span: AstSpan(vec![Span { start: 75, end: 77, file: None }]),
+            },
+        ],
+        takes: 3,
+        returns: 0,
+        span: AstSpan(vec![
+            Span { start: 0, end: 6, file: None },
+            Span { start: 8, end: 12, file: None },
+            Span { start: 14, end: 24, file: None },
+            Span { start: 25, end: 25, file: None },
+            Span { start: 26, end: 26, file: None },
+            Span { start: 28, end: 28, file: None },
+            Span { start: 30, end: 34, file: None },
+            Span { start: 35, end: 35, file: None },
+            Span { start: 36, end: 36, file: None },
+            Span { start: 37, end: 37, file: None },
+            Span { start: 39, end: 45, file: None },
+            Span { start: 46, end: 46, file: None },
+            Span { start: 47, end: 47, file: None },
+            Span { start: 48, end: 48, file: None },
+            Span { start: 50, end: 50, file: None },
+            Span { start: 54, end: 55, file: None },
+            Span { start: 57, end: 62, file: None },
+            Span { start: 67, end: 68, file: None },
+            Span { start: 72, end: 73, file: None },
+            Span { start: 75, end: 77, file: None },
+            Span { start: 79, end: 79, file: None },
+        ]),
+        outlined: false,
+        test: false,
+    };
+    assert_eq!(macro_definition, expected);
+    assert_eq!(parser.current_token.kind, TokenKind::Eof);
+}

--- a/huff_parser/tests/padded.rs
+++ b/huff_parser/tests/padded.rs
@@ -5,7 +5,7 @@ use huff_utils::{evm::Opcode, prelude::*};
 #[test]
 fn macro_with_simple_body() {
     let source =
-        "#define macro HELLO_WORLD() = takes(3) returns(0) {\n #define padded(17) {\n 0x00 mstore\n 0x01 0x02 add \n} 0x69 0x69 return\n}";
+        "#define macro HELLO_WORLD() = takes(3) returns(0) {\n #define padded(7) {\n 0x00 mstore\n 0x01 0x02 add \n}\n}";
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source.source);
     let tokens = lexer.into_iter().map(|x| x.unwrap()).collect::<Vec<Token>>();
@@ -13,6 +13,8 @@ fn macro_with_simple_body() {
 
     // Grab the first macro
     let macro_definition = parser.parse().unwrap().macros[0].clone();
+    
+    // TODO fix expected spans
     let expected = MacroDefinition {
         name: "HELLO_WORLD".to_string(),
         decorator: None,
@@ -37,6 +39,14 @@ fn macro_with_simple_body() {
             Statement {
                 ty: StatementType::Opcode(Opcode::Add),
                 span: AstSpan(vec![Span { start: 75, end: 77, file: None }]),
+            },
+            Statement {
+                ty: StatementType::Opcode(Opcode::Stop),
+                span: AstSpan(vec![]), // TODO wat do?
+            },
+            Statement {
+                ty: StatementType::Opcode(Opcode::Stop),
+                span: AstSpan(vec![]), // TODO wat do?
             },
         ],
         takes: 3,

--- a/huff_utils/src/error.rs
+++ b/huff_utils/src/error.rs
@@ -63,6 +63,8 @@ pub enum ParserErrorKind {
     InvalidDecoratorFlag(String),
     /// Invalid decorator flag argument
     InvalidDecoratorFlagArg(TokenKind),
+    /// Invalid padded code block size
+    InvalidPaddedSize(usize, usize),
 }
 
 /// A Lexing Error
@@ -487,6 +489,9 @@ impl fmt::Display for CompilerError {
                         dfa,
                         pe.spans.error(pe.hint.as_ref())
                     )
+                }
+                ParserErrorKind::InvalidPaddedSize(declared_size, actual_size) => {
+                    write!(f, "\nError: Invalid padded code block size: declared size : {} , actual size {}", declared_size, actual_size)
                 }
             },
             CompilerError::PathBufRead(os_str) => {

--- a/huff_utils/src/token.rs
+++ b/huff_utils/src/token.rs
@@ -63,6 +63,8 @@ pub enum TokenKind {
     Indexed,
     /// "FREE_STORAGE_POINTER()" keyword
     FreeStoragePointer,
+    /// "padded" keyword
+    Padded,
     /// An Identifier
     Ident(String),
     /// Equal Sign
@@ -166,6 +168,7 @@ impl fmt::Display for TokenKind {
             TokenKind::Takes => "takes",
             TokenKind::Returns => "returns",
             TokenKind::FreeStoragePointer => "FREE_STORAGE_POINTER()",
+            TokenKind::Padded => "padded",
             TokenKind::Ident(s) => return write!(f, "{s}"),
             TokenKind::Assign => "=",
             TokenKind::OpenParen => "(",


### PR DESCRIPTION
## Overview
A PR to support the request from issue #301.

Made minimal changes to add support for a `padded` keyword, adding it to the langauge grammar and allow for a macro to have a `#define padded` directive within it.
The parser's Statement generation LGTM upon a manual inspection of the (failing) added test in `huff_parser/tests/padded.rs`, although I'm currently stuck, as I don't how to handle the generated `stop` opcodes ast `Span`s, given they're not present in the source file. What should we set their `Span` to?

Looking for suggestions on how to solve this issue and feedback on the work done sor far!

<!--
Thank you for creating a Pull Request!
Please provide a short description here and review the requirements below.
Bug fixes and new features should include tests.

Make sure to run these checks before opening a pr!
```sh
cargo check --all
cargo test --all --all-features
cargo +nightly fmt -- --check
cargo +nightly clippy --all --all-features -- -D warnings
```

Recommended method to auto format your code before pushing:
```sh
cargo +nightly fmt --all
```
-->
