### PR TITLE
chore: throw error with duplicated destination labels

### DIFF
--- a/huff_codegen/src/lib.rs
+++ b/huff_codegen/src/lib.rs
@@ -300,7 +300,7 @@ impl Codegen {
         let circular_codesize_invocations = circular_codesize_invocations.unwrap_or(&mut ccsi);
 
         // Loop through all intermediate bytecode representations generated from the AST
-        for (_ir_bytes_index, ir_byte) in ir_bytes.iter().enumerate() {
+        for ir_byte in ir_bytes.iter() {
             let starting_offset = offset;
             match &ir_byte.ty {
                 IRByteType::Bytes(b) => {

--- a/huff_core/benches/huff_benchmark.rs
+++ b/huff_core/benches/huff_benchmark.rs
@@ -17,7 +17,7 @@ fn lex_erc20_from_source_benchmark(c: &mut Criterion) {
     .collect();
 
     // Recurse file deps + generate flattened source
-    let file_source = file_sources.get(0).unwrap();
+    let file_source = file_sources.first().unwrap();
     let recursed_file_source =
         Compiler::recurse_deps(Arc::clone(file_source), &files::Remapper::new("./"), file_provider)
             .unwrap();
@@ -48,7 +48,7 @@ fn parse_erc20_benchmark(c: &mut Criterion) {
     .collect();
 
     // Recurse file deps + generate flattened source
-    let file_source = file_sources.get(0).unwrap();
+    let file_source = file_sources.first().unwrap();
     let recursed_file_source =
         Compiler::recurse_deps(Arc::clone(file_source), &files::Remapper::new("./"), file_provider)
             .unwrap();
@@ -84,7 +84,7 @@ fn codegen_erc20_benchmark(c: &mut Criterion) {
     .collect();
 
     // Recurse file deps + generate flattened source
-    let file_source = file_sources.get(0).unwrap();
+    let file_source = file_sources.first().unwrap();
     let recursed_file_source =
         Compiler::recurse_deps(Arc::clone(file_source), &files::Remapper::new("./"), file_provider)
             .unwrap();
@@ -133,7 +133,7 @@ fn erc20_compilation_benchmark(c: &mut Criterion) {
             .collect();
 
         // Recurse file deps + generate flattened source
-        let file_source = file_sources.get(0).unwrap();
+        let file_source = file_sources.first().unwrap();
         let recursed_file_source = Compiler::recurse_deps(
             Arc::clone(file_source),
             &files::Remapper::new("./"),
@@ -180,7 +180,7 @@ fn erc721_compilation_benchmark(c: &mut Criterion) {
             .collect();
 
         // Recurse file deps + generate flattened source
-        let file_source = file_sources.get(0).unwrap();
+        let file_source = file_sources.first().unwrap();
         let recursed_file_source = Compiler::recurse_deps(
             Arc::clone(file_source),
             &files::Remapper::new("./"),

--- a/huff_core/tests/erc20.rs
+++ b/huff_core/tests/erc20.rs
@@ -18,7 +18,7 @@ fn test_erc20_compile() {
     .collect();
 
     // Recurse file deps + generate flattened source
-    let file_source = file_sources.get(0).unwrap();
+    let file_source = file_sources.first().unwrap();
     let recursed_file_source =
         Compiler::recurse_deps(Arc::clone(file_source), &files::Remapper::new("./"), file_provider)
             .unwrap();

--- a/huff_core/tests/erc721.rs
+++ b/huff_core/tests/erc721.rs
@@ -18,7 +18,7 @@ fn test_erc721_compile() {
     .collect();
 
     // Recurse file deps + generate flattened source
-    let file_source = file_sources.get(0).unwrap();
+    let file_source = file_sources.first().unwrap();
     let recursed_file_source =
         Compiler::recurse_deps(Arc::clone(file_source), &files::Remapper::new("./"), file_provider)
             .unwrap();

--- a/huff_lexer/tests/tables.rs
+++ b/huff_lexer/tests/tables.rs
@@ -12,7 +12,7 @@ fn parses_jump_table() {
         .filter(|x| !matches!(x.kind, TokenKind::Whitespace))
         .collect::<Vec<Token>>();
 
-    assert_eq!(tokens.get(0).unwrap().kind, TokenKind::Define);
+    assert_eq!(tokens.first().unwrap().kind, TokenKind::Define);
     assert_eq!(tokens.get(1).unwrap().kind, TokenKind::JumpTable);
     assert_eq!(tokens.get(2).unwrap().kind, TokenKind::Ident(String::from("JUMP_TABLE")));
     assert_eq!(tokens.get(3).unwrap().kind, TokenKind::OpenParen);
@@ -30,7 +30,7 @@ fn parses_packed_jump_table() {
         .filter(|x| !matches!(x.kind, TokenKind::Whitespace))
         .collect::<Vec<Token>>();
 
-    assert_eq!(tokens.get(0).unwrap().kind, TokenKind::Define);
+    assert_eq!(tokens.first().unwrap().kind, TokenKind::Define);
     assert_eq!(tokens.get(1).unwrap().kind, TokenKind::JumpTablePacked);
     assert_eq!(tokens.get(2).unwrap().kind, TokenKind::Ident(String::from("JUMP_TABLE_PACKED")));
     assert_eq!(tokens.get(3).unwrap().kind, TokenKind::OpenParen);
@@ -48,7 +48,7 @@ fn parses_code_table() {
         .filter(|x| !matches!(x.kind, TokenKind::Whitespace))
         .collect::<Vec<Token>>();
 
-    assert_eq!(tokens.get(0).unwrap().kind, TokenKind::Define);
+    assert_eq!(tokens.first().unwrap().kind, TokenKind::Define);
     assert_eq!(tokens.get(1).unwrap().kind, TokenKind::CodeTable);
     assert_eq!(tokens.get(2).unwrap().kind, TokenKind::Ident(String::from("CODE_TABLE")));
     assert_eq!(tokens.get(3).unwrap().kind, TokenKind::OpenParen);

--- a/huff_parser/src/lib.rs
+++ b/huff_parser/src/lib.rs
@@ -35,7 +35,7 @@ pub struct Parser {
 impl Parser {
     /// Public associated function that instantiates a Parser.
     pub fn new(tokens: Vec<Token>, base: Option<String>) -> Self {
-        let initial_token = tokens.get(0).unwrap().clone();
+        let initial_token = tokens.first().unwrap().clone();
         let remapper = files::Remapper::new("./");
         Self { tokens, cursor: 0, current_token: initial_token, base, spans: vec![], remapper }
     }
@@ -44,7 +44,7 @@ impl Parser {
     ///
     /// PANICS if the tokens vec is empty!
     pub fn reset(&mut self) {
-        self.current_token = self.tokens.get(0).unwrap().clone();
+        self.current_token = self.tokens.first().unwrap().clone();
         self.cursor = 0;
     }
 
@@ -191,7 +191,7 @@ impl Parser {
     fn check_label(&self, label: &str, label_set: &mut HashSet<String>) -> Result<(), ParserError> {
         if label_set.contains(label) {
             tracing::error!(target: "parser", "DUPLICATED LABEL NAME: {}", label);
-            return Err(ParserError {
+            Err(ParserError {
                 kind: ParserErrorKind::DuplicateLabel(label.to_string()),
                 hint: Some(format!("Duplicated label name: \"{label}\"")),
                 spans: AstSpan(self.spans.clone()),

--- a/huff_parser/tests/labels.rs
+++ b/huff_parser/tests/labels.rs
@@ -1,10 +1,6 @@
 use huff_lexer::*;
 use huff_parser::*;
-use huff_utils::{
-    evm::Opcode,
-    error::ParserErrorKind,
-    prelude::*
-};
+use huff_utils::{error::ParserErrorKind, evm::Opcode, prelude::*};
 
 #[test]
 fn multiline_labels() {
@@ -438,7 +434,6 @@ pub fn builtins_under_labels() {
     }
 }
 
-
 #[test]
 fn duplicated_labels() {
     let source = r#"
@@ -464,5 +459,8 @@ fn duplicated_labels() {
     // Grab the first macro
     let parse_result = parser.parse();
     assert!(parse_result.is_err());
-    assert_eq!(parse_result.unwrap_err().kind, ParserErrorKind::DuplicateLabel("dup_label".to_string()));
+    assert_eq!(
+        parse_result.unwrap_err().kind,
+        ParserErrorKind::DuplicateLabel("dup_label".to_string())
+    );
 }

--- a/huff_parser/tests/labels.rs
+++ b/huff_parser/tests/labels.rs
@@ -437,18 +437,13 @@ pub fn builtins_under_labels() {
 #[test]
 fn duplicated_labels() {
     let source = r#"
-    #define macro HELLO_WORLD() = takes(3) returns(0) {
-      0x00 mstore
-      0x01 0x02 add
-      dup_label:
-        HELLO()
-        0x00 0x00 revert
-      cool_label:
-        HELLO()
-        0x00 0x00 return
-      dup_label:
-        HELLO()
-        0x00 0x00 return
+    #define macro MAIN() = takes(0) returns(0) {
+        cool_label jump
+        cool_label jump
+
+        cool_label: 0x00
+        dup_label: 0x00
+        dup_label: 0x00
     }
     "#;
     let flattened_source = FullFileSource { source, file: None, spans: vec![] };

--- a/huff_utils/src/abi.rs
+++ b/huff_utils/src/abi.rs
@@ -78,7 +78,7 @@ impl From<ast::Contract> for Abi {
             .filter(|m| m.name.to_lowercase() == "constructor")
             .cloned()
             .collect::<Vec<ast::FunctionDefinition>>()
-            .get(0)
+            .first()
             .map(|func| Constructor {
                 inputs: func
                     .inputs
@@ -97,7 +97,7 @@ impl From<ast::Contract> for Abi {
                     .filter(|m| m.name == "CONSTRUCTOR")
                     .cloned()
                     .collect::<Vec<ast::MacroDefinition>>()
-                    .get(0)
+                    .first()
                     .map(|func| Constructor {
                         inputs: func
                             .parameters

--- a/huff_utils/src/ast.rs
+++ b/huff_utils/src/ast.rs
@@ -33,8 +33,7 @@ impl AstSpan {
     pub fn error(&self, hint: Option<&String>) -> String {
         let file_to_source_map =
             self.0.iter().fold(BTreeMap::<String, Vec<&Span>>::new(), |mut m, s| {
-                let file_name =
-                    s.file.as_ref().map(|f2| f2.path.clone()).unwrap_or_else(|| "".to_string());
+                let file_name = s.file.as_ref().map(|f2| f2.path.clone()).unwrap_or_default();
                 let mut new_vec: Vec<&Span> = m.get(&file_name).cloned().unwrap_or_default();
                 new_vec.push(s);
                 m.insert(file_name, new_vec);
@@ -167,7 +166,7 @@ impl Contract {
                 .iter()
                 .filter(|pointer| pointer.0.eq(&c.name))
                 .collect::<Vec<&(String, [u8; 32])>>()
-                .get(0)
+                .first()
             {
                 Some(p) => {
                     *c = ConstantDefinition {
@@ -248,7 +247,7 @@ impl Contract {
                         .iter()
                         .filter(|md| md.name.eq(&mi.macro_name))
                         .collect::<Vec<&MacroDefinition>>()
-                        .get(0)
+                        .first()
                     {
                         Some(&md) => {
                             if md.name.eq("CONSTRUCTOR") {
@@ -278,7 +277,7 @@ impl Contract {
                                 .iter()
                                 .filter(|md| md.name.eq(name))
                                 .collect::<Vec<&MacroDefinition>>()
-                                .get(0)
+                                .first()
                             {
                                 Some(&md) => {
                                     if md.name.eq("CONSTRUCTOR") {
@@ -335,7 +334,7 @@ impl Contract {
             .iter()
             .filter(|pointer| pointer.0.eq(const_name))
             .collect::<Vec<&(String, [u8; 32])>>()
-            .get(0)
+            .first()
             .is_none()
         {
             tracing::debug!(target: "ast", "No storage pointer already set for \"{}\"!", const_name);
@@ -347,7 +346,7 @@ impl Contract {
                 .iter()
                 .filter(|c| c.name.eq(const_name))
                 .collect::<Vec<&ConstantDefinition>>()
-                .get(0)
+                .first()
             {
                 Some(c) => {
                     let new_value = match c.value {

--- a/huff_utils/src/error.rs
+++ b/huff_utils/src/error.rs
@@ -63,6 +63,8 @@ pub enum ParserErrorKind {
     InvalidDecoratorFlag(String),
     /// Invalid decorator flag argument
     InvalidDecoratorFlagArg(TokenKind),
+    /// Duplicate label
+    DuplicateLabel(String),
 }
 
 /// A Lexing Error
@@ -485,6 +487,14 @@ impl fmt::Display for CompilerError {
                         f,
                         "\nError: Invalid Decorator Flag Argument: \"{}\" \n{}\n",
                         dfa,
+                        pe.spans.error(pe.hint.as_ref())
+                    )
+                }
+                ParserErrorKind::DuplicateLabel(label) => {
+                    write!(
+                        f,
+                        "\nError: Duplicate label: \"{}\" \n{}\n",
+                        label,
                         pe.spans.error(pe.hint.as_ref())
                     )
                 }


### PR DESCRIPTION
## Overview

This PR addresses [issue #295](https://github.com/huff-language/huff-rs/issues/295) and aims to fulfill the feature requests made by @erhant and @Philogy.

### Proposed Changes

- Implement a contract-wide label uniqueness check.
- Newly defined labels are validated against a hashset to ensure no duplication occurs across the entire contract.
- Duplicated label definitions will throw `ParserErrorKind::DuplicateLabel(String)`.

### Caveats

- `test_erc721_compile` currently fails due to non-unique labels (`error` and `cont`) in `huff-examples/erc721/contracts/ERC721.huff`.
- To resolve this, the labels in `ERC721.huff` should be renamed for uniqueness.

### Impact

- This change ensures label uniqueness across the entire contract, preventing potential bugs related to label name collisions.
- A decision is needed on renaming labels in `ERC721.huff` to ensure all tests pass with the new label uniqueness constraints.
