### PR TITLE
feat: show cursor on parser error

### DIFF
--- a/huff_core/tests/parser_errors.rs
+++ b/huff_core/tests/parser_errors.rs
@@ -42,6 +42,7 @@ fn test_invalid_macro_statement() {
                     kind: ParserErrorKind::InvalidTokenInMacroBody(TokenKind::FreeStoragePointer),
                     hint: None,
                     spans: AstSpan(vec![Span { start: const_start, end: const_end, file: None }]),
+                    cursor: 36,
                 }
             )
         }
@@ -72,6 +73,7 @@ fn test_unexpected_type() {
                         end: source.find("internal").unwrap_or(0) + "internal".len() - 1,
                         file: None
                     }]),
+                    cursor: 5,
                 }
             )
         }
@@ -103,6 +105,7 @@ fn test_invalid_definition() {
                         end: source.find("invalid").unwrap_or(0) + "invalid".len() - 1,
                         file: None
                     }]),
+                    cursor: 1,
                 }
             )
         }
@@ -147,6 +150,7 @@ fn test_invalid_constant_value() {
                             end: source.find(value).unwrap_or(0) + value.len() - 1,
                             file: None
                         }]),
+                        cursor: 4
                     }
                 )
             }
@@ -191,6 +195,7 @@ fn test_invalid_token_in_macro_body() {
                             end: source.rfind(value).unwrap_or(0) + value.len() - 1,
                             file: None
                         }]),
+                        cursor: 15,
                     }
                 )
             }
@@ -236,6 +241,7 @@ fn test_invalid_token_in_label_definition() {
                             end: source.rfind(value).unwrap_or(0) + value.len() - 1,
                             file: None
                         }]),
+                        cursor: 17,
                     }
                 )
             }
@@ -279,6 +285,7 @@ fn test_invalid_single_arg() {
                         ))),
                         hint: Some("Expected number representing stack item count.".to_string()),
                         spans: AstSpan(vec![Span { start: 34, end: 34, file: None }]),
+                        cursor: 8,
                     }
                 )
             }

--- a/huff_parser/src/lib.rs
+++ b/huff_parser/src/lib.rs
@@ -135,7 +135,7 @@ impl Parser {
                     )),
                     spans: AstSpan(self.spans.clone()),
                     cursor: self.cursor,
-                })
+                });
             }
         }
 
@@ -161,7 +161,7 @@ impl Parser {
                     hint: Some(format!("Expected import string. Got: \"{tok}\"")),
                     spans: AstSpan(new_spans),
                     cursor: self.cursor,
-                })
+                });
             }
         };
 
@@ -202,6 +202,7 @@ impl Parser {
                 kind: ParserErrorKind::DuplicateMacro(m.name.to_owned()),
                 hint: Some("MACRO names should be unique".to_string()),
                 spans: AstSpan(vec![m.span[2].clone()]),
+                cursor: self.cursor,
             })
         } else {
             Ok(())
@@ -262,7 +263,7 @@ impl Parser {
                     hint: Some(format!("Expected function name, found: \"{tok}\"")),
                     spans: AstSpan(self.spans.clone()),
                     cursor: self.cursor,
-                })
+                });
             }
         };
 
@@ -326,7 +327,7 @@ impl Parser {
                     hint: Some(format!("Expected event name, found: \"{tok}\"")),
                     spans: AstSpan(self.spans.clone()),
                     cursor: self.cursor,
-                })
+                });
             }
         };
 
@@ -358,7 +359,7 @@ impl Parser {
                     hint: Some("Expected constant name.".to_string()),
                     spans: AstSpan(self.spans.clone()),
                     cursor: self.cursor,
-                })
+                });
             }
         };
 
@@ -384,8 +385,11 @@ impl Parser {
                     ),
                     spans: AstSpan(vec![self.current_token.span.clone()]),
                     cursor: self.cursor,
-                })
+                });
             }
+        };
+
+        // Clone spans and set to nothing
         let new_spans = self.spans.clone();
         self.spans = vec![];
 
@@ -410,7 +414,7 @@ impl Parser {
                     hint: Some("Expected error name.".to_string()),
                     spans: AstSpan(self.spans.clone()),
                     cursor: self.cursor,
-                })
+                });
             }
         };
 
@@ -458,7 +462,7 @@ impl Parser {
                                 hint: Some(format!("Expected string for decorator flag: {s}")),
                                 spans: AstSpan(vec![self.current_token.span.clone()]),
                                 cursor: self.cursor,
-                            })
+                            });
                         }
                     }
                     // The value flag accepts a single literal as an argument
@@ -475,7 +479,7 @@ impl Parser {
                                 hint: Some(format!("Expected literal for decorator flag: {s}")),
                                 spans: AstSpan(vec![self.current_token.span.clone()]),
                                 cursor: self.cursor,
-                            })
+                            });
                         }
                     }
                     Err(_) => {
@@ -485,8 +489,11 @@ impl Parser {
                             hint: Some(format!("Unknown decorator flag: {s}")),
                             spans: AstSpan(self.spans.clone()),
                             cursor: self.cursor,
-                        })
+                        });
                     }
+                }
+
+                // Consume the closing parenthesis
                 self.match_kind(TokenKind::CloseParen)?;
 
                 // Multiple flags are possible
@@ -501,7 +508,7 @@ impl Parser {
                     hint: Some(String::from("Unknown decorator flag")),
                     spans: AstSpan(self.spans.clone()),
                     cursor: self.cursor,
-                })
+                });
             }
         }
 
@@ -715,7 +722,7 @@ impl Parser {
                         hint: None,
                         spans: AstSpan(vec![self.current_token.span.clone()]),
                         cursor: self.cursor,
-                    })
+                    });
                 }
             };
         }
@@ -829,7 +836,7 @@ impl Parser {
                         hint: None,
                         spans: AstSpan(vec![self.current_token.span.clone()]),
                         cursor: self.cursor,
-                    })
+                    });
                 }
             };
         }
@@ -961,7 +968,7 @@ impl Parser {
                                     )),
                                     spans: AstSpan(vec![self.current_token.span.clone()]),
                                     cursor: self.cursor,
-                                })
+                                });
                             }
                         }
                         TokenKind::PrimitiveType(ty) => {
@@ -996,7 +1003,7 @@ impl Parser {
                     hint: None,
                     spans: AstSpan(vec![self.current_token.span.clone()]),
                     cursor: self.cursor,
-                })
+                });
             }
 
             arg.span = AstSpan(arg_spans);
@@ -1076,7 +1083,7 @@ impl Parser {
                         ),
                         spans: AstSpan(new_spans),
                         cursor: self.cursor,
-                    })
+                    });
                 }
             }
             if self.check(TokenKind::Comma) {
@@ -1303,6 +1310,9 @@ impl Parser {
                         cursor: self.cursor,
                     })
                 }
+                Ok(self.match_kind(self.current_token.kind.clone())?)
+            }
+            PrimitiveEVMType::Bool => Ok(self.match_kind(self.current_token.kind.clone())?),
             PrimitiveEVMType::Address => Ok(self.match_kind(self.current_token.kind.clone())?),
             PrimitiveEVMType::String => Ok(self.match_kind(self.current_token.kind.clone())?),
             PrimitiveEVMType::DynBytes => Ok(self.match_kind(self.current_token.kind.clone())?),

--- a/huff_parser/src/lib.rs
+++ b/huff_parser/src/lib.rs
@@ -119,6 +119,7 @@ impl Parser {
                             kind: ParserErrorKind::InvalidDefinition(self.current_token.kind.clone()),
                             hint: Some("Definition must be one of: `function`, `event`, `constant`, `error`, `macro`, `fn`, or `test`.".to_string()),
                             spans: AstSpan(vec![self.current_token.span.clone()]),
+                            cursor: self.cursor,
                         });
                     }
                 };
@@ -132,6 +133,7 @@ impl Parser {
                         TokenKind::Include
                     )),
                     spans: AstSpan(self.spans.clone()),
+                    cursor: self.cursor,
                 })
             }
         }
@@ -157,6 +159,7 @@ impl Parser {
                     kind: ParserErrorKind::InvalidName(tok.clone()),
                     hint: Some(format!("Expected import string. Got: \"{tok}\"")),
                     spans: AstSpan(new_spans),
+                    cursor: self.cursor,
                 })
             }
         };
@@ -176,6 +179,7 @@ impl Parser {
                 kind: ParserErrorKind::UnexpectedType(self.current_token.kind.clone()),
                 hint: Some(format!("Expected: \"{kind}\"")),
                 spans: AstSpan(self.spans.clone()),
+                cursor: self.cursor,
             })
         }
     }
@@ -238,6 +242,7 @@ impl Parser {
                     kind: ParserErrorKind::InvalidName(tok.clone()),
                     hint: Some(format!("Expected function name, found: \"{tok}\"")),
                     spans: AstSpan(self.spans.clone()),
+                    cursor: self.cursor,
                 })
             }
         };
@@ -257,6 +262,7 @@ impl Parser {
                         "Expected one of: `view`, `pure`, `payable`, `nonpayable`.".to_string(),
                     ),
                     spans: AstSpan(vec![self.current_token.span.clone()]),
+                    cursor: self.cursor,
                 })
             }
         };
@@ -300,6 +306,7 @@ impl Parser {
                     kind: ParserErrorKind::InvalidName(tok.clone()),
                     hint: Some(format!("Expected event name, found: \"{tok}\"")),
                     spans: AstSpan(self.spans.clone()),
+                    cursor: self.cursor,
                 })
             }
         };
@@ -331,6 +338,7 @@ impl Parser {
                     kind: ParserErrorKind::UnexpectedType(tok),
                     hint: Some("Expected constant name.".to_string()),
                     spans: AstSpan(self.spans.clone()),
+                    cursor: self.cursor,
                 })
             }
         };
@@ -356,6 +364,7 @@ impl Parser {
                             .to_string(),
                     ),
                     spans: AstSpan(vec![self.current_token.span.clone()]),
+                    cursor: self.cursor,
                 })
             }
         };
@@ -384,6 +393,7 @@ impl Parser {
                     kind: ParserErrorKind::UnexpectedType(tok),
                     hint: Some("Expected error name.".to_string()),
                     spans: AstSpan(self.spans.clone()),
+                    cursor: self.cursor,
                 })
             }
         };
@@ -431,6 +441,7 @@ impl Parser {
                                 ),
                                 hint: Some(format!("Expected string for decorator flag: {s}")),
                                 spans: AstSpan(vec![self.current_token.span.clone()]),
+                                cursor: self.cursor,
                             })
                         }
                     }
@@ -447,6 +458,7 @@ impl Parser {
                                 ),
                                 hint: Some(format!("Expected literal for decorator flag: {s}")),
                                 spans: AstSpan(vec![self.current_token.span.clone()]),
+                                cursor: self.cursor,
                             })
                         }
                     }
@@ -456,6 +468,7 @@ impl Parser {
                             kind: ParserErrorKind::InvalidDecoratorFlag(s.clone()),
                             hint: Some(format!("Unknown decorator flag: {s}")),
                             spans: AstSpan(self.spans.clone()),
+                            cursor: self.cursor,
                         })
                     }
                 }
@@ -474,6 +487,7 @@ impl Parser {
                     )),
                     hint: Some(String::from("Unknown decorator flag")),
                     spans: AstSpan(self.spans.clone()),
+                    cursor: self.cursor,
                 })
             }
         }
@@ -578,6 +592,7 @@ impl Parser {
                                             "Literal {hex_literal:?} contains too many bytes for opcode \"{o:?}\""
                                         )),
                                         spans: AstSpan(curr_spans),
+                                        cursor: self.cursor,
                                     });
                                 }
 
@@ -595,6 +610,7 @@ impl Parser {
                                         o, self.current_token.kind
                                     )),
                                     spans: AstSpan(vec![self.current_token.span.clone()]),
+                                    cursor: self.cursor,
                                 })
                             }
                         }
@@ -683,6 +699,7 @@ impl Parser {
                         kind: ParserErrorKind::InvalidTokenInMacroBody(kind),
                         hint: None,
                         spans: AstSpan(vec![self.current_token.span.clone()]),
+                        cursor: self.cursor,
                     })
                 }
             };
@@ -796,6 +813,7 @@ impl Parser {
                         kind: ParserErrorKind::InvalidTokenInLabelDefinition(kind),
                         hint: None,
                         spans: AstSpan(vec![self.current_token.span.clone()]),
+                        cursor: self.cursor,
                     })
                 }
             };
@@ -927,6 +945,7 @@ impl Parser {
                                         "Argument names cannot be EVM types: {arg_str}"
                                     )),
                                     spans: AstSpan(vec![self.current_token.span.clone()]),
+                                    cursor: self.cursor,
                                 })
                             }
                         }
@@ -937,6 +956,7 @@ impl Parser {
                                 ),
                                 hint: Some(format!("Argument names cannot be EVM types: {ty}")),
                                 spans: AstSpan(vec![self.current_token.span.clone()]),
+                                cursor: self.cursor,
                             })
                         }
                         _ => { /* continue, valid string */ }
@@ -960,6 +980,7 @@ impl Parser {
                     kind: ParserErrorKind::InvalidArgs(self.current_token.kind.clone()),
                     hint: None,
                     spans: AstSpan(vec![self.current_token.span.clone()]),
+                    cursor: self.cursor,
                 })
             }
 
@@ -983,6 +1004,7 @@ impl Parser {
                     kind: ParserErrorKind::InvalidSingleArg(self.current_token.kind.clone()),
                     hint: Some("Expected number representing stack item count.".to_string()),
                     spans: AstSpan(single_arg_span),
+                    cursor: self.cursor,
                 })
             }
         };
@@ -1038,6 +1060,7 @@ impl Parser {
                                 .to_string(),
                         ),
                         spans: AstSpan(new_spans),
+                        cursor: self.cursor,
                     })
                 }
             }
@@ -1126,6 +1149,7 @@ impl Parser {
                                     ),
                                     hint: Some("Expected valid hex bytecode.".to_string()),
                                     spans: AstSpan(new_spans),
+                                    cursor: self.cursor,
                                 })
                             }
                         } else {
@@ -1141,6 +1165,7 @@ impl Parser {
                         kind: ParserErrorKind::InvalidTableBodyToken(kind.clone()),
                         hint: Some("Expected an identifier string.".to_string()),
                         spans: AstSpan(new_spans),
+                        cursor: self.cursor,
                     })
                 }
             };
@@ -1168,6 +1193,7 @@ impl Parser {
                     kind: ParserErrorKind::InvalidConstant(kind),
                     hint: None,
                     spans: AstSpan(new_spans),
+                    cursor: self.cursor,
                 })
             }
         }
@@ -1200,6 +1226,7 @@ impl Parser {
                     kind: ParserErrorKind::InvalidArgCallIdent(kind),
                     hint: None,
                     spans: AstSpan(new_spans),
+                    cursor: self.cursor,
                 })
             }
         }
@@ -1229,6 +1256,7 @@ impl Parser {
                 kind: ParserErrorKind::InvalidArgs(kind),
                 hint: None,
                 spans: AstSpan(vec![self.current_token.span.clone()]),
+                cursor: self.cursor,
             }),
         }
     }
@@ -1246,6 +1274,7 @@ impl Parser {
                         kind: ParserErrorKind::InvalidUint256(size),
                         hint: None,
                         spans: AstSpan(vec![self.current_token.span.clone()]),
+                        cursor: self.cursor,
                     })
                 }
                 Ok(self.match_kind(self.current_token.kind.clone())?)
@@ -1256,6 +1285,7 @@ impl Parser {
                         kind: ParserErrorKind::InvalidBytes(size),
                         hint: None,
                         spans: AstSpan(vec![self.current_token.span.clone()]),
+                        cursor: self.cursor,
                     })
                 }
                 Ok(self.match_kind(self.current_token.kind.clone())?)
@@ -1270,6 +1300,7 @@ impl Parser {
                         kind: ParserErrorKind::InvalidInt(size),
                         hint: None,
                         spans: AstSpan(vec![self.current_token.span.clone()]),
+                        cursor: self.cursor,
                     })
                 }
                 let curr_token_kind = self.current_token.kind.clone();

--- a/huff_parser/tests/macro.rs
+++ b/huff_parser/tests/macro.rs
@@ -1291,7 +1291,7 @@ fn test_duplicate_macro_error() {
                         end: occurrences[1].1,
                         file: None
                     }]),
-                    cursor: 58, 
+                    cursor: 58,
                 }
             )
         }

--- a/huff_parser/tests/macro.rs
+++ b/huff_parser/tests/macro.rs
@@ -1291,6 +1291,7 @@ fn test_duplicate_macro_error() {
                         end: occurrences[1].1,
                         file: None
                     }]),
+                    cursor: 58, 
                 }
             )
         }

--- a/huff_utils/src/error.rs
+++ b/huff_utils/src/error.rs
@@ -16,6 +16,8 @@ pub struct ParserError {
     pub hint: Option<String>,
     /// A collection of spans the Parser Error crosses
     pub spans: AstSpan,
+    /// Line number where the error was seen
+    pub cursor: usize,
 }
 
 /// A Type of Parser Error
@@ -324,7 +326,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidPush(op) => {
                     write!(
                         f,
-                        "\nError: Invalid use of \"{:?}\" \n{}\n",
+                        "\nError at token {}: Invalid use of \"{:?}\" \n{}\n",
+                        pe.cursor,
                         op,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -332,7 +335,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::UnexpectedType(ut) => {
                     write!(
                         f,
-                        "\nError: Unexpected Type: \"{}\" \n{}\n",
+                        "\nError at token {}: Unexpected Type: \"{}\" \n{}\n",
+                        pe.cursor,
                         ut,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -340,7 +344,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidTypeAsArgumentName(ut) => {
                     write!(
                         f,
-                        "\nError: Unexpected Argument Name is an EVM Type: \"{}\" \n{}\n",
+                        "\nError at token {}: Unexpected Argument Name is an EVM Type: \"{}\" \n{}\n",
+                        pe.cursor,
                         ut,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -348,7 +353,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidDefinition(k) => {
                     write!(
                         f,
-                        "\nError: Invalid Defintion \"{}\"\n{}\n",
+                        "\nError at token {}: Invalid Defintion \"{}\"\n{}\n",
+                        pe.cursor,
                         k,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -356,7 +362,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidConstantValue(cv) => {
                     write!(
                         f,
-                        "\nError: Invalid Constant Value: \"{}\" \n{}\n",
+                        "\nError at token {}: Invalid Constant Value: \"{}\" \n{}\n",
+                        pe.cursor,
                         cv,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -364,7 +371,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidTokenInMacroBody(tmb) => {
                     write!(
                         f,
-                        "\nError: Invalid Token In Macro Body: \"{}\" \n{}\n",
+                        "\nError at token {}: Invalid Token In Macro Body: \"{}\" \n{}\n",
+                        pe.cursor,
                         tmb,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -372,7 +380,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidTokenInLabelDefinition(tlb) => {
                     write!(
                         f,
-                        "\nError: Invalid Token In Label Defintiion: \"{}\" \n{}\n",
+                        "\nError at token {}: Invalid Token In Label Defintiion: \"{}\" \n{}\n",
+                        pe.cursor,
                         tlb,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -380,7 +389,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidSingleArg(sa) => {
                     write!(
                         f,
-                        "\nError: Invalid Argument: \"{}\" \n{}\n",
+                        "\nError at token {}: Invalid Argument: \"{}\" \n{}\n",
+                        pe.cursor,
                         sa,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -388,7 +398,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidTableBodyToken(tbt) => {
                     write!(
                         f,
-                        "\nError: Invalid Token In Table Body: \"{}\" \n{}\n",
+                        "\nError at token {}: Invalid Token In Table Body: \"{}\" \n{}\n",
+                        pe.cursor,
                         tbt,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -396,7 +407,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidConstant(constant) => {
                     write!(
                         f,
-                        "\nError: Invalid Constant: \"{}\" \n{}\n",
+                        "\nError at token {}: Invalid Constant: \"{}\" \n{}\n",
+                        pe.cursor,
                         constant,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -404,7 +416,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidArgCallIdent(aci) => {
                     write!(
                         f,
-                        "\nError: Invalid Argument Call Identifier: \"{}\" \n{}\n",
+                        "\nError at token {}: Invalid Argument Call Identifier: \"{}\" \n{}\n",
+                        pe.cursor,
                         aci,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -412,7 +425,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidName(name) => {
                     write!(
                         f,
-                        "\nError: Invalid Name: \"{}\" \n{}\n",
+                        "\nError at token {}: Invalid Name: \"{}\" \n{}\n",
+                        pe.cursor,
                         name,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -420,7 +434,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidArgs(args) => {
                     write!(
                         f,
-                        "\nError: Invalid Argument Type: \"{}\" \n{}\n",
+                        "\nError at token {}: Invalid Argument Type: \"{}\" \n{}\n",
+                        pe.cursor,
                         args,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -428,7 +443,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidUint256(v) => {
                     write!(
                         f,
-                        "\nError: Invalid Uint256 Value: \"{}\" \n{}\n",
+                        "\nError at token {}: Invalid Uint256 Value: \"{}\" \n{}\n",
+                        pe.cursor,
                         v,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -436,7 +452,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidBytes(b) => {
                     write!(
                         f,
-                        "\nError: Invalid Bytes Value: \"{}\" \n{}\n",
+                        "\nError at token {}: Invalid Bytes Value: \"{}\" \n{}\n",
+                        pe.cursor,
                         b,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -444,7 +461,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidInt(i) => {
                     write!(
                         f,
-                        "\nError: Invalid Int Value: \"{}\" \n{}\n",
+                        "\nError at token {}: Invalid Int Value: \"{}\" \n{}\n",
+                        pe.cursor,
                         i,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -452,7 +470,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidMacroArgs(ma) => {
                     write!(
                         f,
-                        "\nError: Invalid Macro Arguments: \"{}\" \n{}\n",
+                        "\nError at token {}: Invalid Macro Arguments: \"{}\" \n{}\n",
+                        pe.cursor,
                         ma,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -460,14 +479,16 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidReturnArgs => {
                     write!(
                         f,
-                        "\nError: Invalid Return Arguments\n{}\n",
+                        "\nError at token {}: Invalid Return Arguments\n{}\n",
+                        pe.cursor,
                         pe.spans.error(pe.hint.as_ref())
                     )
                 }
                 ParserErrorKind::InvalidImportPath(ip) => {
                     write!(
                         f,
-                        "\nError: Invalid Import Path: \"{}\" \n{}\n",
+                        "\nError at token {}: Invalid Import Path: \"{}\" \n{}\n",
+                        pe.cursor,
                         ip,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -475,7 +496,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidDecoratorFlag(df) => {
                     write!(
                         f,
-                        "\nError: Invalid Decorator Flag: \"{}\" \n{}\n",
+                        "\nError at token {}: Invalid Decorator Flag: \"{}\" \n{}\n",
+                        pe.cursor,
                         df,
                         pe.spans.error(pe.hint.as_ref())
                     )
@@ -483,7 +505,8 @@ impl fmt::Display for CompilerError {
                 ParserErrorKind::InvalidDecoratorFlagArg(dfa) => {
                     write!(
                         f,
-                        "\nError: Invalid Decorator Flag Argument: \"{}\" \n{}\n",
+                        "\nError at token {}: Invalid Decorator Flag Argument: \"{}\" \n{}\n",
+                        pe.cursor,
                         dfa,
                         pe.spans.error(pe.hint.as_ref())
                     )


### PR DESCRIPTION
fix #312

## Overview

When a parsing error happens, it can be very helpful to give a hint to the developer where the error happened. In a future PR, I would love to add the line number but for now, I think the cursor is a good quick win.

Before: 
```
Error: Unexpected Type: "#define" 
Expected one of: `view`, `pure`, `payable`, `nonpayable`.
```

After:
```
Error at token 27: Unexpected Type: "#define" 
Expected one of: `view`, `pure`, `payable`, `nonpayable`.
```


<!--
Thank you for creating a Pull Request!
Please provide a short description here and review the requirements below.
Bug fixes and new features should include tests.

Make sure to run these checks before opening a pr!
```sh
cargo check --all
cargo test --all --all-features
cargo +nightly fmt -- --check
cargo +nightly clippy --all --all-features -- -D warnings
```

Recommended method to auto format your code before pushing:
```sh
cargo +nightly fmt --all
```
-->
